### PR TITLE
Deprecate setCaseSentivice in favor of new setCaseSensitive.

### DIFF
--- a/src/main/java/ome/services/SearchBean.java
+++ b/src/main/java/ome/services/SearchBean.java
@@ -633,6 +633,12 @@ public class SearchBean extends AbstractStatefulBean implements Search {
     @Transactional
     @RolesAllowed("user")
     public void setCaseSentivice(boolean caseSensitive) {
+        setCaseSensitive(caseSensitive);
+    }
+
+    @Transactional
+    @RolesAllowed("user")
+    public void setCaseSensitive(boolean caseSensitive) {
         synchronized (values) {
             values.caseSensitive = caseSensitive;
         }

--- a/src/test/java/ome/server/utests/SearchBeanTest.java
+++ b/src/test/java/ome/server/utests/SearchBeanTest.java
@@ -120,7 +120,7 @@ public class SearchBeanTest extends MockObjectTestCase {
     public void testResetDefaults() {
         bean = new SearchBean(executor, analyzer);
         bean.setBatchSize(4);
-        bean.setCaseSentivice(false);
+        bean.setCaseSensitive(false);
         bean.setMergedBatches(true);
         bean.setReturnUnloaded(true);
         // Disallowed bean.setUseProjections(true);


### PR DESCRIPTION
The Search API has a `setCaseSentivice` which is deprecated in favor of a new `setCaseSensitive` method.