### PR TITLE
Deprecate graph util methods expected to be removed.

### DIFF
--- a/src/main/java/ome/services/graphs/ModelObjectSequencer.java
+++ b/src/main/java/ome/services/graphs/ModelObjectSequencer.java
@@ -36,7 +36,9 @@ import com.google.common.collect.Ordering;
  * This class groups the utility methods for performing such ordering.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.1
+ * @deprecated in anticipation of refactoring
  */
+@Deprecated
 public class ModelObjectSequencer {
     /**
      * Sort a list of original file IDs such that files precede containing directories.


### PR DESCRIPTION
Deprecating some graph utility methods that probably nobody will miss and that are not expected to be needed by 5.5.1 at the latest. Companion to https://github.com/ome/omero-blitz/pull/14.