### PR TITLE
Open files as read-only if read-write would fail.

### DIFF
--- a/src/main/java/ome/services/RawFileBean.java
+++ b/src/main/java/ome/services/RawFileBean.java
@@ -357,16 +357,16 @@ public class RawFileBean extends AbstractStatefulBean implements RawFileStore {
             String mode = "r";
             final File osFile = new File(ioService.getFilesPath(file.getId()));
             if (!osFile.exists() || osFile.canWrite()) {
-            try {
-                if (admin.canUpdate(file)) {
-                    mode = "rw";
+                try {
+                    if (admin.canUpdate(file)) {
+                        mode = "rw";
+                    }
+                } catch (InternalException ie) {
+                    // ticket:10657 this is caused by the current
+                    // group being set to "-1" meaning no write permission
+                    // logic can be assumed.
+                    log.warn("No permissions info: using 'r' as mode for file " + fileId);
                 }
-            } catch (InternalException ie) {
-                // ticket:10657 this is caused by the current
-                // group being set to "-1" meaning no write permission
-                // logic can be assumed.
-                log.warn("No permissions info: using 'r' as mode for file " + fileId);
-            }
             }
 
             if (buffer == null) {

--- a/src/main/java/ome/services/RawFileBean.java
+++ b/src/main/java/ome/services/RawFileBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2017 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2006-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -355,6 +355,8 @@ public class RawFileBean extends AbstractStatefulBean implements RawFileStore {
             file = iQuery.get(OriginalFile.class, fileId);
 
             String mode = "r";
+            final File osFile = new File(ioService.getFilesPath(file.getId()));
+            if (!osFile.exists() || osFile.canWrite()) {
             try {
                 if (admin.canUpdate(file)) {
                     mode = "rw";
@@ -364,6 +366,7 @@ public class RawFileBean extends AbstractStatefulBean implements RawFileStore {
                 // group being set to "-1" meaning no write permission
                 // logic can be assumed.
                 log.warn("No permissions info: using 'r' as mode for file " + fileId);
+            }
             }
 
             if (buffer == null) {


### PR DESCRIPTION
If OMERO permissions afford write access to an attachment but operating system permissions afford only read access to the underlying file then client download of the attachment would fail with an error. This PR adjusts the server to open a file read-only if it already exists and is read-only. It should remain possible to attach new files but existing files should become downloadable regardless of operating system write access.