### PR TITLE
Cast ByteBuffer to Byte for JDK8 support

### DIFF
--- a/src/main/java/ome/services/RawFileBean.java
+++ b/src/main/java/ome/services/RawFileBean.java
@@ -22,6 +22,7 @@ package ome.services;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.NonWritableChannelException;
@@ -476,7 +477,7 @@ public class RawFileBean extends AbstractStatefulBean implements RawFileStore {
     public void write(byte[] buf, long position, int length) {
         errorIfNotLoaded();
         ByteBuffer nioBuffer = MappedByteBuffer.wrap(buf);
-        nioBuffer.limit(length);
+        ((Buffer) nioBuffer).limit(length);
 
         if (diskSpaceChecking) {
             iRepositoryInfo.sanityCheckRepository();


### PR DESCRIPTION
Calls to RawFileBean.write throw:
```
Wrapped Exception: (java.lang.NoSuchMethodError): java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer
```
when this component is compiled with JDK9+ and the server is then run on JDK8. The issue is in the following block:

```
    @RolesAllowed("user")
    public void write(byte[] buf, long position, int length) {
        errorIfNotLoaded();
        ByteBuffer nioBuffer = MappedByteBuffer.wrap(buf);
        nioBuffer.limit(length);
```
JDK 9 added a covariant return type for `limit` as well as several other methods (see https://github.com/apache/felix/pull/114) which are not present in `rt.jar` on JDK 8. With this cast, the compiled code should result in:

```
javap -v -l -p -c -s -sysinfo -constants -cp omero-server*B.jar ome.services.RawFileBean | grep -E "(major version|limit)"
  major version: 52
  #120 = Methodref          #390.#401     // java/nio/ByteBuffer.limit:(I)Ljava/nio/Buffer;
  #401 = NameAndType        #509:#510     // limit:(I)Ljava/nio/Buffer;
  #509 = Utf8               limit
        14: invokevirtual #120                // Method java/nio/ByteBuffer.limit:(I)Ljava/nio/Buffer;
```

rather than

```
javap -v -l -p -c -s -sysinfo -constants -cp omero-server.jar ome.services.RawFileBean | grep -E "(major version|limit)"
  major version: 52
  #120 = Methodref          #257.#391     // java/nio/ByteBuffer.limit:(I)Ljava/nio/ByteBuffer;
  #391 = NameAndType        #499:#500     // limit:(I)Ljava/nio/ByteBuffer;
  #499 = Utf8               limit
        14: invokevirtual #120                // Method java/nio/ByteBuffer.limit:(I)Ljava/nio/ByteBuffer;
```