### PR TITLE
Remove omero.versions from properties file

### DIFF
--- a/src/main/resources/ome/services/startup.xml
+++ b/src/main/resources/ome/services/startup.xml
@@ -22,6 +22,26 @@
   HOOKS : These beans are used to provide startup and shutdown logic.
   </description>
 
+  <bean id="version.package" class="ome.system.UpgradeCheck"
+        factory-method="getPackage"/>
+  <bean id="omero.version" factory-bean="version.package"
+        factory-method="getImplementationVersion"/>
+  <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="targetObject">
+            <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+                <property name="targetClass" value="java.lang.System" />
+                <property name="targetMethod" value="getProperties" />
+            </bean>
+        </property>
+        <property name="targetMethod" value="setProperty" />
+        <property name="arguments">
+            <list>
+                <value>omero.verison</value>
+                <ref bean="omero.version"/>
+            </list>
+        </property>
+    </bean>
+
   <bean id="dbPatchCheck"
      class="ome.services.util.DBPatchCheck"
      init-method="start" lazy-init="false">

--- a/src/main/resources/omero.properties
+++ b/src/main/resources/omero.properties
@@ -953,11 +953,3 @@ omero.client.browser.thumb_default_size=96
 Ice.IPv6=1
 
 ### END
-
-#############################################
-## Server product name for release artifacts
-#############################################
-product.name=OMERO.server
-
-
-omero.version=5.5.0-SNAPSHOT

--- a/src/main/resources/omero.properties
+++ b/src/main/resources/omero.properties
@@ -960,4 +960,4 @@ Ice.IPv6=1
 product.name=OMERO.server
 
 
-omero.version=5.4.10-ice36-SNAPSHOT
+omero.version=5.5.0-SNAPSHOT


### PR DESCRIPTION
To do this properly:

 * find all uses of omero.properties and change to something jar specific (cc: @jburel @rgozim)
 * add a configuration property (incl. environment variable?) for only warning on a differing version to the Java Gateway (cc: @dominikl)

Opening this PR so devspace can pass, but this either needs to be extended or closed in favor of a better solution.

--exclude