### PR TITLE
Use lucene 2.4 search behaviour

### DIFF
--- a/src/main/java/ome/services/search/FullText.java
+++ b/src/main/java/ome/services/search/FullText.java
@@ -158,7 +158,7 @@ public class FullText extends SearchAction {
         
         try {
             final Analyzer a = analyzer.newInstance();
-            final QueryParser parser = new /*Analyzing*/QueryParser(Version.LUCENE_31, "combined_fields", a);
+            final QueryParser parser = new /*Analyzing*/QueryParser(Version.LUCENE_24, "combined_fields", a);
             parser.setAllowLeadingWildcard(values.leadingWildcard);
             q = parser.parse(queryStr);
         } catch (ParseException pe) {


### PR DESCRIPTION
Just sets QueryParser to use lucene version 2.4 syntax. 
Test: Search for something like "aaa-bbb" and make sure only results containing "aaa-bbb" are returned and not "aaa" and "bbb".

