### PR TITLE
Have model graph traversal use less Guava.

### DIFF
--- a/src/main/java/ome/services/graphs/GraphPathBean.java
+++ b/src/main/java/ome/services/graphs/GraphPathBean.java
@@ -20,6 +20,7 @@
 package ome.services.graphs;
 
 import java.lang.reflect.Modifier;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -50,7 +51,6 @@ import org.springframework.context.event.ContextRefreshedEvent;
 import com.google.common.base.Joiner;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 
 import ome.model.IObject;
@@ -358,7 +358,8 @@ public class GraphPathBean extends OnContextRefreshedEventListener {
                     sb.append(" from ");
                     sb.append(superclassWithProperty);
                 } else {
-                    final Entry<String, String> classPropertyFullName = Maps.immutableEntry(property.holder, fullPropertyPath);
+                    final Entry<String, String> classPropertyFullName =
+                            new AbstractMap.SimpleImmutableEntry<>(property.holder, fullPropertyPath);
                     if (interfaceForProperty != null) {
                         sb.append(" see ");
                         final String implementedInterface = interfaceForProperty.getName();
@@ -367,13 +368,14 @@ public class GraphPathBean extends OnContextRefreshedEventListener {
                         /* It would be nice to set PropertyDetails to have the interface as the holder,
                          * but then properties would not be unique by declarer class and instance ID. */
                     }
-                    final Entry<String, String> classPropertyShortName = Maps.immutableEntry(property.holder, shortPropertyPath);
+                    final Entry<String, String> classPropertyShortName =
+                            new AbstractMap.SimpleImmutableEntry<>(property.holder, shortPropertyPath);
                     /* entity linkages by non-inherited properties are recorded */
                     if (valueClassName == null) {
                         simplePropertiesNested.put(property.holder, fullPropertyPath);
                         simplePropertiesDirect.put(property.holder, shortPropertyPath);
                     } else {
-                        linkedTo.put(property.holder, Maps.immutableEntry(valueClassName, fullPropertyPath));
+                        linkedTo.put(property.holder, new AbstractMap.SimpleImmutableEntry<>(valueClassName, fullPropertyPath));
                         linkedBy.put(valueClassName, classPropertyFullName);
                     }
                     final PropertyKind propertyKind;
@@ -523,7 +525,7 @@ public class GraphPathBean extends OnContextRefreshedEventListener {
      * @return the kind of property it is
      */
     public PropertyKind getPropertyKind(String className, String propertyName) {
-        return propertyKinds.get(Maps.immutableEntry(className, propertyName));
+        return propertyKinds.get(new AbstractMap.SimpleImmutableEntry<>(className, propertyName));
     }
 
     /**
@@ -533,7 +535,7 @@ public class GraphPathBean extends OnContextRefreshedEventListener {
      * @return the Hibernate type of the property
      */
     public Type getPropertyType(String className, String propertyName) {
-        return propertyTypes.get(Maps.immutableEntry(className, propertyName));
+        return propertyTypes.get(new AbstractMap.SimpleImmutableEntry<>(className, propertyName));
     }
 
     /**
@@ -543,7 +545,7 @@ public class GraphPathBean extends OnContextRefreshedEventListener {
      * @return the implemented interface, may be {@code null}
      */
     public String getInterfaceImplemented(String className, String propertyName) {
-        return implementedInterfaces.get(Maps.immutableEntry(className, propertyName));
+        return implementedInterfaces.get(new AbstractMap.SimpleImmutableEntry<>(className, propertyName));
     }
 
     /**
@@ -553,7 +555,7 @@ public class GraphPathBean extends OnContextRefreshedEventListener {
      * @return if the property can be accessed
      */
     public boolean isPropertyAccessible(String className, String propertyName) {
-        return accessibleProperties.contains(Maps.immutableEntry(className, propertyName));
+        return accessibleProperties.contains(new AbstractMap.SimpleImmutableEntry<>(className, propertyName));
     }
 
     /**

--- a/src/main/java/ome/services/graphs/GraphTraversal.java
+++ b/src/main/java/ome/services/graphs/GraphTraversal.java
@@ -19,6 +19,7 @@
 
 package ome.services.graphs;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -47,7 +48,6 @@ import com.google.common.base.Objects;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 
@@ -532,7 +532,7 @@ public class GraphTraversal {
         for (final CI deletedObject : planning.deleted) {
             deleted.put(deletedObject.className, deletedObject.id);
         }
-        return Maps.immutableEntry(included, deleted);
+        return new AbstractMap.SimpleImmutableEntry<>(included, deleted);
     }
 
     /**
@@ -582,7 +582,7 @@ public class GraphTraversal {
         for (final CI deletedObject : planning.deleted) {
             deleted.add(deletedObject.toIObject());
         }
-        return Maps.immutableEntry(included, deleted);
+        return new AbstractMap.SimpleImmutableEntry<>(included, deleted);
     }
 
     /**
@@ -911,7 +911,7 @@ public class GraphTraversal {
             } else if (!planning.detailsNoted.containsKey(linked)) {
                 log.warn("failed to query for " + linked);
             } else {
-                linkerLinked.add(Maps.immutableEntry(linker, linked));
+                linkerLinked.add(new AbstractMap.SimpleImmutableEntry<>(linker, linked));
                 if (propertyIsAccessible) {
                     planning.befores.put(linked, linker);
                     planning.afters.put(linker, linked);
@@ -1282,7 +1282,7 @@ public class GraphTraversal {
                 idMap = HashMultimap.create();
                 linkerToIdToLinked.put(linker.toCP(), idMap);
             }
-            idMap.put(linker.id, Maps.immutableEntry(linked.className, linked.id));
+            idMap.put(linker.id, new AbstractMap.SimpleImmutableEntry<>(linked.className, linked.id));
         }
     }
 
@@ -1623,7 +1623,7 @@ public class GraphTraversal {
                 final Collection<Long> allIds = oneClassToDelete.getValue();
                 assertMayBeDeleted(className, allIds);
             }
-            toJoinAndDelete.add(Maps.immutableEntry(eachToJoin, eachToDelete));
+            toJoinAndDelete.add(new AbstractMap.SimpleImmutableEntry<>(eachToJoin, eachToDelete));
         }
         return new PlanExecutor() {
             @Override

--- a/src/main/java/ome/services/query/HierarchyNavigator.java
+++ b/src/main/java/ome/services/query/HierarchyNavigator.java
@@ -19,6 +19,7 @@
 
 package ome.services.query;
 
+import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -32,7 +33,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 
@@ -58,35 +58,36 @@ public class HierarchyNavigator {
     static {
         /* note that there is not yet any treatment of PlateAcquisition or WellSample */
         final Builder<Map.Entry<String, String>, String> builder = ImmutableMap.builder();
-        builder.put(Maps.immutableEntry("Folder", "Folder"),  /* cannot distinguish ascent from descent, guess the latter */
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Folder", "Folder"),
+                /* cannot distinguish ascent from descent, guess the latter */
                 "SELECT parentFolder.id, id FROM Folder WHERE parentFolder.id IN (:" + Parameters.IDS + ")");
-        builder.put(Maps.immutableEntry("Folder", "Image"),
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Folder", "Image"),
                 "SELECT parent.id, child.id FROM FolderImageLink WHERE parent.id IN (:" + Parameters.IDS + ")");
-        builder.put(Maps.immutableEntry("Project", "Dataset"),
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Project", "Dataset"),
                 "SELECT parent.id, child.id FROM ProjectDatasetLink WHERE parent.id IN (:" + Parameters.IDS + ")");
-        builder.put(Maps.immutableEntry("Dataset", "Image"),
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Dataset", "Image"),
                 "SELECT parent.id, child.id FROM DatasetImageLink WHERE parent.id IN (:" + Parameters.IDS + ")");
-        builder.put(Maps.immutableEntry("Screen", "Plate"),
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Screen", "Plate"),
                 "SELECT parent.id, child.id FROM ScreenPlateLink WHERE parent.id IN (:" + Parameters.IDS + ")");
-        builder.put(Maps.immutableEntry("Plate", "Well"),
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Plate", "Well"),
                 "SELECT plate.id, id FROM Well WHERE plate.id IN (:" + Parameters.IDS + ")");
-        builder.put(Maps.immutableEntry("Well", "Image"),
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Well", "Image"),
                 "SELECT well.id, image.id FROM WellSample WHERE well.id IN (:" + Parameters.IDS + ")");
-        builder.put(Maps.immutableEntry("Fileset", "Image"),
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Fileset", "Image"),
                 "SELECT fileset.id, id FROM Image WHERE fileset.id IN (:" + Parameters.IDS + ")");
-        builder.put(Maps.immutableEntry("Image", "Fileset"),
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Image", "Fileset"),
                 "SELECT id, fileset.id FROM Image WHERE fileset.id IS NOT NULL AND id IN (:" + Parameters.IDS + ")");
-        builder.put(Maps.immutableEntry("Image", "Well"),
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Image", "Well"),
                 "SELECT image.id, well.id FROM WellSample WHERE image.id IN (:" + Parameters.IDS + ")");
-        builder.put(Maps.immutableEntry("Well", "Plate"),
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Well", "Plate"),
                 "SELECT id, plate.id FROM Well WHERE id IN (:" + Parameters.IDS + ")");
-        builder.put(Maps.immutableEntry("Plate", "Screen"),
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Plate", "Screen"),
                 "SELECT child.id, parent.id FROM ScreenPlateLink WHERE child.id IN (:" + Parameters.IDS + ")");
-        builder.put(Maps.immutableEntry("Image", "Dataset"),
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Image", "Dataset"),
                 "SELECT child.id, parent.id FROM DatasetImageLink WHERE child.id IN (:" + Parameters.IDS + ")");
-        builder.put(Maps.immutableEntry("Dataset", "Project"),
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Dataset", "Project"),
                 "SELECT child.id, parent.id FROM ProjectDatasetLink WHERE child.id IN (:" + Parameters.IDS + ")");
-        builder.put(Maps.immutableEntry("Image", "Folder"),
+        builder.put(new AbstractMap.SimpleImmutableEntry<>("Image", "Folder"),
                 "SELECT child.id, parent.id FROM FolderImageLink WHERE child.id IN (:" + Parameters.IDS + ")");
         hqlFromTo = builder.build();
     }
@@ -113,7 +114,7 @@ public class HierarchyNavigator {
      * @return pairs of database IDs: of the query object, and an object to which it relates
      */
     private List<Object[]> doQuery(String toType, String fromType, Collection<Long> fromIds) {
-        final String queryString = hqlFromTo.get(Maps.immutableEntry(fromType, toType));
+        final String queryString = hqlFromTo.get(new AbstractMap.SimpleImmutableEntry<>(fromType, toType));
         if (queryString == null) {
             throw new IllegalArgumentException("not implemented for " + fromType + " to " + toType);
         }


### PR DESCRIPTION
This should not change behavior because it simply uses the standard library where we can easily avoid resorting to a third-party library. Server should work just as before.