### PR TITLE
Have indexer handle failure to query model objects.

### DIFF
--- a/src/main/java/ome/services/fulltext/FullTextIndexer2.java
+++ b/src/main/java/ome/services/fulltext/FullTextIndexer2.java
@@ -53,6 +53,7 @@ import org.hibernate.jdbc.Work;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.SearchFactory;
+import org.hibernate.search.bridge.BridgeException;
 import org.hibernate.search.bridge.FieldBridge;
 import org.python.google.common.base.Splitter;
 import org.quartz.DateBuilder;
@@ -552,6 +553,12 @@ public class FullTextIndexer2 {
             toIndex.clear();
         } catch (UnresolvableObjectException uoe) {
             hibernateQueryError = uoe;
+        } catch (BridgeException be) {
+            if (be.getCause() instanceof UnresolvableObjectException) {
+                hibernateQueryError = (UnresolvableObjectException) be.getCause();
+            } else {
+                throw be;
+            }
         } finally {
             DetailsFieldBridge.unlock();
             session.close();
@@ -619,6 +626,12 @@ public class FullTextIndexer2 {
             toPurge.clear();
         } catch (UnresolvableObjectException uoe) {
             hibernateQueryError = uoe;
+        } catch (BridgeException be) {
+            if (be.getCause() instanceof UnresolvableObjectException) {
+                hibernateQueryError = (UnresolvableObjectException) be.getCause();
+            } else {
+                throw be;
+            }
         } finally {
             DetailsFieldBridge.unlock();
             session.close();


### PR DESCRIPTION
The `Indexer-0.log` from the https://web-proxy.openmicroscopy.org/west-ci/job/OMERO-test-integration/390/testReport/junit/OmeroPy.test.integration.test_search/ failure revealed that Hibernate's `Query.list()` can throw `org.hibernate.ObjectNotFoundException` in reading OMERO model objects. Perhaps this relates to reading some transient inconsistent state in the model graph with the stand-in indexer's transactions *not* being managed by Spring. This PR has the indexer thread catch such cases, pause awhile then retry the indexing run.