### PR TITLE
Have PixelsService use omero.pixeldata.memoizer.dir for cache.

### DIFF
--- a/src/main/resources/ome/services/service-ome.io.nio.PixelsService.xml
+++ b/src/main/resources/ome/services/service-ome.io.nio.PixelsService.xml
@@ -2,7 +2,7 @@
 <!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # 
-# Copyright 2006-2018 University of Dundee. All rights reserved.
+# Copyright 2006-2019 University of Dundee. All rights reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -31,6 +31,7 @@
   <bean name="/OMERO/Pixels" class="ome.io.nio.PixelsService"
         parent="filesystem">
     <!-- note constructor-args from parent bean -->
+    <constructor-arg value="${omero.pixeldata.memoizer.dir}"/>
     <constructor-arg ref="MemoizerWait"/>
     <constructor-arg ref="omeroFilePathResolver"/>
     <constructor-arg ref="backOff"/>


### PR DESCRIPTION
By default the Bio-Formats cache is located in `${omero.data.dir}/BioFormatsCache`. This PR allows that default to be effectively overridden by setting the `omero.pixeldata.memoizer.dir` property introduced by https://github.com/ome/omero-model/pull/29 so as to address the deficiency described in https://trello.com/c/yzXcSYfe/142-bioformatscache-should-be-configurable.