### PR TITLE
Enforce a timeout on server queries.

### DIFF
--- a/src/main/java/ome/logic/QueryImpl.java
+++ b/src/main/java/ome/logic/QueryImpl.java
@@ -314,7 +314,6 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
 
             }
         });
-
     }
 
     @Override

--- a/src/main/java/ome/logic/QueryImpl.java
+++ b/src/main/java/ome/logic/QueryImpl.java
@@ -18,6 +18,7 @@ import ome.api.IQuery;
 import ome.api.ServiceInterface;
 import ome.api.local.LocalQuery;
 import ome.conditions.ApiUsageException;
+import ome.conditions.OverUsageException;
 import ome.conditions.ValidationException;
 import ome.model.IObject;
 import ome.parameters.Filter;
@@ -158,7 +159,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
             return (T) getHibernateTemplate().execute(callback);
         } catch (DataAccessResourceFailureException e) {
             if (isProbablyTimeout(e)) {
-                throw new ApiUsageException("query failed, probable timeout");
+                throw new OverUsageException("query failed, probable timeout");
             } else {
                 throw e;
             }
@@ -175,7 +176,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
             return (T) getHibernateTemplate().execute(query);
         } catch (DataAccessResourceFailureException e) {
             if (isProbablyTimeout(e)) {
-                throw new ApiUsageException("query failed, probable timeout");
+                throw new OverUsageException("query failed, probable timeout");
             } else {
                 throw e;
             }

--- a/src/main/java/ome/services/SearchBean.java
+++ b/src/main/java/ome/services/SearchBean.java
@@ -33,6 +33,7 @@ import ome.services.search.SomeMustNone;
 import ome.services.search.TagsAndGroups;
 import ome.services.search.Union;
 import ome.services.util.Executor;
+import ome.services.util.TimeoutSetter;
 import ome.system.SelfConfigurableService;
 
 import org.slf4j.Logger;
@@ -62,9 +63,12 @@ public class SearchBean extends AbstractStatefulBean implements Search {
 
     private/* final */transient Executor executor;
 
+    private transient TimeoutSetter timeoutSetter;
+
     private/* final */transient Class<? extends Analyzer> analyzer;
 
     private/* final */transient Integer maxClauseCount;
+
 
     public SearchBean(Executor executor, Class<? extends Analyzer> analyzer) {
         this.executor = executor;
@@ -89,6 +93,11 @@ public class SearchBean extends AbstractStatefulBean implements Search {
      */
     public void setExecutor(Executor executor) {
         this.executor = executor;
+    }
+
+    public void setTimeoutSetter(TimeoutSetter timeoutSetter) {
+        getBeanHelper().throwIfAlreadySet(this.timeoutSetter, timeoutSetter);
+        this.timeoutSetter = timeoutSetter;
     }
 
     /**
@@ -269,6 +278,7 @@ public class SearchBean extends AbstractStatefulBean implements Search {
             return false;
         }
         SearchAction action = actions.popFirst();
+        timeoutSetter.setTimeout(action::setTimeout);
         List<IObject> list = (List<IObject>) executor.execute(null, action);
         results.add(list);
         return hasNext(); // recursive call

--- a/src/main/java/ome/services/SearchBean.java
+++ b/src/main/java/ome/services/SearchBean.java
@@ -17,6 +17,7 @@ import ome.api.Search;
 import ome.api.ServiceInterface;
 import ome.conditions.ApiUsageException;
 import ome.conditions.InternalException;
+import ome.conditions.OverUsageException;
 import ome.logic.QueryImpl;
 import ome.model.IObject;
 import ome.model.annotations.Annotation;
@@ -285,7 +286,7 @@ public class SearchBean extends AbstractStatefulBean implements Search {
             list = (List<IObject>) executor.execute(null, action);
         } catch (DataAccessResourceFailureException e) {
             if (QueryImpl.isProbablyTimeout(e)) {
-                throw new ApiUsageException("query failed, probable timeout");
+                throw new OverUsageException("query failed, probable timeout");
             } else {
                 throw e;
             }

--- a/src/main/java/ome/services/SearchBean.java
+++ b/src/main/java/ome/services/SearchBean.java
@@ -71,7 +71,6 @@ public class SearchBean extends AbstractStatefulBean implements Search {
 
     private/* final */transient Integer maxClauseCount;
 
-
     public SearchBean(Executor executor, Class<? extends Analyzer> analyzer) {
         this.executor = executor;
         this.analyzer = analyzer;

--- a/src/main/java/ome/services/SearchBean.java
+++ b/src/main/java/ome/services/SearchBean.java
@@ -17,6 +17,7 @@ import ome.api.Search;
 import ome.api.ServiceInterface;
 import ome.conditions.ApiUsageException;
 import ome.conditions.InternalException;
+import ome.logic.QueryImpl;
 import ome.model.IObject;
 import ome.model.annotations.Annotation;
 import ome.model.internal.Details;
@@ -39,7 +40,6 @@ import ome.system.SelfConfigurableService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.lucene.analysis.Analyzer;
-import org.postgresql.util.PSQLException;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -284,9 +284,8 @@ public class SearchBean extends AbstractStatefulBean implements Search {
         try {
             list = (List<IObject>) executor.execute(null, action);
         } catch (DataAccessResourceFailureException e) {
-            /* see QueryImpl.execute */
-            if (e.getCause() instanceof PSQLException) {
-                throw new ApiUsageException("query failed: " + e.getCause());
+            if (QueryImpl.isProbablyTimeout(e)) {
+                throw new ApiUsageException("query failed, probable timeout");
             } else {
                 throw e;
             }

--- a/src/main/java/ome/services/query/Query.java
+++ b/src/main/java/ome/services/query/Query.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2006-2017 University of Dundee. All rights reserved.
+ *   Copyright 2006-2019 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -100,6 +100,8 @@ public abstract class Query<T> implements HibernateCallback {
 
     /* if the Hibernate level 2 cache should be used */
     private Boolean isCacheable = null;
+
+    private Integer timeout = null;
 
     /**
      * one of two possible outcomes of the {@link #buildQuery(Session)} method.
@@ -239,6 +241,9 @@ public abstract class Query<T> implements HibernateCallback {
             }
             
             if (_query != null) {
+                if (timeout != null) {
+                    _query.setTimeout(timeout);
+                }
                 _query.setFirstResult(offset);
                 _query.setMaxResults(limit);
                 if (isCacheable != null) {
@@ -247,6 +252,9 @@ public abstract class Query<T> implements HibernateCallback {
                 }
                 return unique ? _query.uniqueResult() : _query.list();
             } else {
+                if (timeout != null) {
+                    _criteria.setTimeout(timeout);
+                }
                 _criteria.setFirstResult(offset);
                 _criteria.setMaxResults(limit);
                 if (isCacheable != null) {
@@ -294,6 +302,13 @@ public abstract class Query<T> implements HibernateCallback {
                     "This Query already has a Query set:" + _query);
         }
         _criteria = criteria;
+    }
+
+    /**
+     * @param seconds the timeout to set
+     */
+    public void setTimeout(int seconds) {
+        timeout = seconds;
     }
 
     /**

--- a/src/main/java/ome/services/search/AnnotatedWith.java
+++ b/src/main/java/ome/services/search/AnnotatedWith.java
@@ -28,6 +28,7 @@ import ome.tools.hibernate.QueryBuilder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.hibernate.Query;
 import org.hibernate.Session;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -236,6 +237,10 @@ public class AnnotatedWith extends SearchAction {
         }
 
         log.debug(qb.toString());
-        return qb.query(session).list();
+        final Query query = qb.query(session);
+        if (timeout != null) {
+            query.setTimeout(timeout);
+        }
+        return query.list();
     }
 }

--- a/src/main/java/ome/services/search/FullText.java
+++ b/src/main/java/ome/services/search/FullText.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2007 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -240,6 +238,9 @@ public class FullText extends SearchAction {
     private Criteria criteria(FullTextSession session) {
         final Class<?> cls = values.onlyTypes.get(0);
         Criteria criteria = session.createCriteria(cls);
+        if (timeout != null) {
+            criteria.setTimeout(timeout);
+        }
         AnnotationCriteria ann = new AnnotationCriteria(criteria,
                 values.fetchAnnotations);
 
@@ -327,6 +328,9 @@ public class FullText extends SearchAction {
 
         // Main query
         FullTextQuery ftQuery = session.createFullTextQuery(this.q, cls);
+        if (timeout != null) {
+            ftQuery.setTimeout(timeout);
+        }
         initializeQuery(ftQuery);
         List<?> result = ftQuery.list();
         int totalSize = ftQuery.getResultSize();

--- a/src/main/java/ome/services/search/SearchAction.java
+++ b/src/main/java/ome/services/search/SearchAction.java
@@ -40,6 +40,8 @@ public abstract class SearchAction implements Serializable,
 
     protected final SearchValues values = new SearchValues();
 
+    protected Integer timeout;
+
     /**
      * List of {@link IObject} instances which have currently been found. This
      * {@link SearchAction} may want to take these values into account if
@@ -53,6 +55,10 @@ public abstract class SearchAction implements Serializable,
                     "SearchValues argument must not be null");
         }
         this.values.copy(values);
+    }
+
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
     }
 
     /**

--- a/src/main/java/ome/services/search/TagsAndGroups.java
+++ b/src/main/java/ome/services/search/TagsAndGroups.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2007 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -82,6 +80,9 @@ public class TagsAndGroups extends SearchAction {
         }
 
         Query query = qb.query(session);
+        if (timeout != null) {
+            query.setTimeout(timeout);
+        }
 
         List<IObject> rv = new ArrayList<IObject>();
         List<String> tags = query.list();

--- a/src/main/java/ome/services/util/TimeoutSetter.java
+++ b/src/main/java/ome/services/util/TimeoutSetter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.services.util;
+
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ome.security.SecuritySystem;
+import ome.system.EventContext;
+
+/**
+ * Sets timeouts for queries according to event context.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.5.0
+ */
+public class TimeoutSetter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TimeoutSetter.class);
+
+    private final SecuritySystem securitySystem;
+
+    private final int timeout, timeoutAdmin;  /* in seconds */
+
+    /**
+     * Construct the timeout setter.
+     * @param securitySystem the security system
+     * @param timeout the timeout to set for regular users, in seconds
+     * @param timeoutAdmin the timeout to set for administrative users, in seconds
+     */
+    public TimeoutSetter(SecuritySystem securitySystem, int timeout, int timeoutAdmin) {
+        if (timeout < 1 || timeoutAdmin < 1) {
+            throw new IllegalArgumentException("query timeouts must be strictly positive");
+        }
+        this.securitySystem = securitySystem;
+        this.timeout = timeout;
+        this.timeoutAdmin = timeoutAdmin;
+        if (timeout == timeoutAdmin) {
+            LOGGER.info("Query timeout set to {}s for all users.", timeout);
+        } else {
+            LOGGER.info("Query timeout set to {}s and for administrators to {}s.", timeout, timeoutAdmin);
+        }
+    }
+
+    /**
+     * Set the timeout on the given query.
+     * @param query a query consuming a timeout setting
+     */
+    public void setTimeout(Consumer<Integer> query) {
+        final EventContext ec = securitySystem.getEventContext();
+        final Long userId = ec.getCurrentUserId();
+        final int selectedTimeout = ec.isCurrentUserAdmin() ? timeoutAdmin : timeout;
+        query.accept(selectedTimeout);
+        if (userId == null) {
+            LOGGER.debug("Set timeout for unknown user's query to {}s.", selectedTimeout);
+        } else {
+            LOGGER.debug("Set timeout for user {}'s query to {}s.", userId, selectedTimeout);
+        }
+    }
+}

--- a/src/main/java/ome/services/util/TimeoutSetter.java
+++ b/src/main/java/ome/services/util/TimeoutSetter.java
@@ -66,9 +66,9 @@ public class TimeoutSetter {
      */
     public void setTimeout(Consumer<Integer> query) {
         final EventContext ec = securitySystem.getEventContext();
-        final Long userId = ec.getCurrentUserId();
         final int selectedTimeout = ec.isCurrentUserAdmin() ? timeoutAdmin : timeout;
         query.accept(selectedTimeout);
+        final Long userId = ec.getCurrentUserId();
         if (userId == null) {
             LOGGER.debug("Set timeout for unknown user's query to {}s.", selectedTimeout);
         } else {

--- a/src/main/resources/ome/services/service-ome.api.IQuery.xml
+++ b/src/main/resources/ome/services/service-ome.api.IQuery.xml
@@ -2,9 +2,7 @@
 <!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # 
-# $Id$
-# 
-# Copyright 2006 University of Dundee. All rights reserved.
+# Copyright 2006-2019 University of Dundee. All rights reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -22,6 +20,7 @@
 
   <alias name="internal-ome.api.IQuery" alias="internal-ome.api.LocalQuery"/> 
   <bean parent="level1" id="internal-ome.api.IQuery" class="ome.logic.QueryImpl">
+    <property name="timeoutSetter" ref="timeoutSetter"/>
     <property name="analyzer" value="${omero.search.analyzer}"/>
   </bean>
  
@@ -29,7 +28,7 @@
     <property name="proxyInterfaces">
       <list>
         <value>ome.api.IQuery</value>
-        <value>ome.api.local.LocalQuery</value>        
+        <value>ome.api.local.LocalQuery</value>
       </list>
     </property>
     <property name="target" ref="internal-ome.api.IQuery"/>

--- a/src/main/resources/ome/services/service-ome.api.Search.xml
+++ b/src/main/resources/ome/services/service-ome.api.Search.xml
@@ -2,8 +2,6 @@
 <!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# $Id$
-#
 # Copyright 2008 Glencoe Software, Inc. All rights reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
@@ -24,6 +22,7 @@
         id="internal-ome.api.Search"
         class="ome.services.SearchBean" scope="prototype">
      <property name="executor" ref="executor"/>
+     <property name="timeoutSetter" ref="timeoutSetter"/>
      <property name="analyzer" value="${omero.search.analyzer}"/>
      <property name="maxClauseCount" value="${omero.search.maxclause}"/>
   </bean>

--- a/src/main/resources/ome/services/services.xml
+++ b/src/main/resources/ome/services/services.xml
@@ -205,6 +205,12 @@
     </property>
   </bean>
 
+  <bean id="timeoutSetter" class="ome.services.util.TimeoutSetter">
+    <constructor-arg ref="securitySystem"/>
+    <constructor-arg value="${omero.query.timeout}"/>
+    <constructor-arg value="${omero.query.timeout.admin}"/>
+  </bean>
+
 <!--
   JMX resources
   =======================================================================

--- a/src/main/resources/omero-server.properties
+++ b/src/main/resources/omero-server.properties
@@ -141,6 +141,15 @@ omero.metrics.graphite=
 omero.metrics.slf4j_minutes=60
 
 
+#############################################
+## Query configuration
+#############################################
+
+# For the query service how many seconds before a query times out.
+omero.query.timeout=1000
+
+# How many seconds before a query times out for administrative users.
+omero.query.timeout.admin=${omero.query.timeout}
 
 
 #############################################

--- a/src/test/java/ome/server/utests/IQueryMockSessionTest.java
+++ b/src/test/java/ome/server/utests/IQueryMockSessionTest.java
@@ -56,7 +56,7 @@ public class IQueryMockSessionTest extends MockObjectTestCase {
         ec.stubs().method("getCurrentUserId").will(returnValue(1L));
         final Mock sec = mock(SecuritySystem.class);
         sec.stubs().method("getEventContext").will(returnValue(ec.proxy()));
-        timeoutSetter = new TimeoutSetter((SecuritySystem) sec.proxy(), 10, 10);
+        timeoutSetter = new TimeoutSetter((SecuritySystem) sec.proxy(), 10, 20);
     }
 
     @Override
@@ -103,7 +103,7 @@ public class IQueryMockSessionTest extends MockObjectTestCase {
 
     protected Mock criteriaUniqueResultCall(Object obj) {
         Mock mockCriteria = mock(Criteria.class);
-        mockCriteria.stubs().method("setTimeout");
+        mockCriteria.stubs().method("setTimeout").with(eq(10));
         mockCriteria.expects(once()).method("uniqueResult").will(
                 returnValue(obj));
         return mockCriteria;
@@ -111,7 +111,7 @@ public class IQueryMockSessionTest extends MockObjectTestCase {
 
     protected Mock criteriaListCall(List blank) {
         Mock mockCriteria = mock(Criteria.class);
-        mockCriteria.stubs().method("setTimeout");
+        mockCriteria.stubs().method("setTimeout").with(eq(10));
         mockCriteria.expects(once()).method("list").will(returnValue(blank));
         return mockCriteria;
     }

--- a/src/test/java/ome/server/utests/IQueryMockSessionTest.java
+++ b/src/test/java/ome/server/utests/IQueryMockSessionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2019 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -16,6 +16,7 @@ import org.jmock.Mock;
 import org.jmock.MockObjectTestCase;
 import org.springframework.aop.framework.ProxyFactory;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -25,9 +26,12 @@ import ome.logic.QueryImpl;
 import ome.model.IObject;
 import ome.model.containers.Project;
 import ome.parameters.Filter;
+import ome.security.SecuritySystem;
 import ome.security.basic.CurrentDetails;
 import ome.server.itests.LoginInterceptor;
 import ome.services.util.ServiceHandler;
+import ome.services.util.TimeoutSetter;
+import ome.system.EventContext;
 import ome.system.Principal;
 
 /**
@@ -42,6 +46,18 @@ public class IQueryMockSessionTest extends MockObjectTestCase {
     protected QueryImpl impl;
 
     protected Mock mockSession, mockFactory;
+
+    protected TimeoutSetter timeoutSetter;
+
+    @BeforeClass
+    public void createMockTimeoutSetter() {
+        final Mock ec = mock(EventContext.class);
+        ec.stubs().method("isCurrentUserAdmin").will(returnValue(false));
+        ec.stubs().method("getCurrentUserId").will(returnValue(1L));
+        final Mock sec = mock(SecuritySystem.class);
+        sec.stubs().method("getEventContext").will(returnValue(ec.proxy()));
+        timeoutSetter = new TimeoutSetter((SecuritySystem) sec.proxy(), 10, 10);
+    }
 
     @Override
     @BeforeMethod(alwaysRun=true)
@@ -71,6 +87,7 @@ public class IQueryMockSessionTest extends MockObjectTestCase {
         mockFactory = mock(SessionFactory.class);
         
         impl.setSessionFactory((SessionFactory) mockFactory.proxy());
+        impl.setTimeoutSetter(timeoutSetter);
 
         ome.model.meta.Session session = new ome.model.meta.Session();
         session.setStarted(new Timestamp(System.currentTimeMillis()));
@@ -86,6 +103,7 @@ public class IQueryMockSessionTest extends MockObjectTestCase {
 
     protected Mock criteriaUniqueResultCall(Object obj) {
         Mock mockCriteria = mock(Criteria.class);
+        mockCriteria.stubs().method("setTimeout");
         mockCriteria.expects(once()).method("uniqueResult").will(
                 returnValue(obj));
         return mockCriteria;
@@ -93,6 +111,7 @@ public class IQueryMockSessionTest extends MockObjectTestCase {
 
     protected Mock criteriaListCall(List blank) {
         Mock mockCriteria = mock(Criteria.class);
+        mockCriteria.stubs().method("setTimeout");
         mockCriteria.expects(once()).method("list").will(returnValue(blank));
         return mockCriteria;
     }
@@ -202,7 +221,6 @@ public class IQueryMockSessionTest extends MockObjectTestCase {
         mockCriteria.expects(once()).method("add");
         mockCriteria.expects(once()).method("setFirstResult");
         mockCriteria.expects(once()).method("setMaxResults");
-
         mockSession.expects(once()).method("createCriteria").will(
                 returnValue(mockCriteria.proxy())).id("test");
         Object retVal = iQuery.findAllByExample(test, new Filter().page(1, 10));

--- a/src/test/java/ome/server/utests/SearchBeanTest.java
+++ b/src/test/java/ome/server/utests/SearchBeanTest.java
@@ -51,7 +51,7 @@ public class SearchBeanTest extends MockObjectTestCase {
         ec.stubs().method("getCurrentUserId").will(returnValue(1L));
         final Mock sec = mock(SecuritySystem.class);
         sec.stubs().method("getEventContext").will(returnValue(ec.proxy()));
-        timeoutSetter = new TimeoutSetter((SecuritySystem) sec.proxy(), 10, 10);
+        timeoutSetter = new TimeoutSetter((SecuritySystem) sec.proxy(), 10, 20);
     }
 
     @Test

--- a/src/test/java/ome/server/utests/SearchBeanTest.java
+++ b/src/test/java/ome/server/utests/SearchBeanTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2019 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -12,17 +12,22 @@ import java.util.List;
 import ome.model.IObject;
 import ome.model.annotations.TagAnnotation;
 import ome.model.core.Image;
+import ome.security.SecuritySystem;
 import ome.services.SearchBean;
 import ome.services.fulltext.FullTextAnalyzer;
 import ome.services.search.SearchAction;
 import ome.services.search.SearchValues;
 import ome.services.util.Executor;
+import ome.services.util.TimeoutSetter;
+import ome.system.EventContext;
 import ome.system.Principal;
 import ome.system.ServiceFactory;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.hibernate.Session;
+import org.jmock.Mock;
 import org.jmock.MockObjectTestCase;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class SearchBeanTest extends MockObjectTestCase {
@@ -37,9 +42,22 @@ public class SearchBeanTest extends MockObjectTestCase {
 
     protected SearchBean bean;
 
+    protected TimeoutSetter timeoutSetter;
+
+    @BeforeClass
+    public void createMockTimeoutSetter() {
+        final Mock ec = mock(EventContext.class);
+        ec.stubs().method("isCurrentUserAdmin").will(returnValue(false));
+        ec.stubs().method("getCurrentUserId").will(returnValue(1L));
+        final Mock sec = mock(SecuritySystem.class);
+        sec.stubs().method("getEventContext").will(returnValue(ec.proxy()));
+        timeoutSetter = new TimeoutSetter((SecuritySystem) sec.proxy(), 10, 10);
+    }
+
     @Test
     public void testDefaults() {
         bean = new SearchBean(executor, analyzer);
+        bean.setTimeoutSetter(timeoutSetter);
         assertDefaults();
     }
 
@@ -55,6 +73,7 @@ public class SearchBeanTest extends MockObjectTestCase {
     @Test
     public void testBasicUsage() {
         bean = new SearchBean(executor, analyzer);
+        bean.setTimeoutSetter(timeoutSetter);
         bean.onlyType(Image.class);
         bean.onlyAnnotatedWith(TagAnnotation.class);
         bean.byFullText("Here's my query");
@@ -63,6 +82,7 @@ public class SearchBeanTest extends MockObjectTestCase {
     @Test
     public void testHasNextWithResults() {
         bean = new SearchBean(executor, analyzer);
+        bean.setTimeoutSetter(timeoutSetter);
         assertFalse(bean.hasNext());
         List<IObject> list = new ArrayList<IObject>();
         list.add(new Image());
@@ -73,6 +93,7 @@ public class SearchBeanTest extends MockObjectTestCase {
     @Test
     public void testHasNextWithAction() {
         bean = new SearchBean(executor, analyzer);
+        bean.setTimeoutSetter(timeoutSetter);
         assertFalse(bean.hasNext());
         addActionWithResultOfSize_n(1);
         assertTrue(bean.hasNext());
@@ -81,6 +102,7 @@ public class SearchBeanTest extends MockObjectTestCase {
     @Test
     public void testActiveQueries() {
         bean = new SearchBean(executor, analyzer);
+        bean.setTimeoutSetter(timeoutSetter);
         addActionWithResultOfSize_n(1);
         assertTrue(bean.activeQueries() == 1);
         assertNotNull(bean.next());
@@ -91,6 +113,7 @@ public class SearchBeanTest extends MockObjectTestCase {
     @Test
     public void testBatchSizeRollOver() {
         bean = new SearchBean(executor, analyzer);
+        bean.setTimeoutSetter(timeoutSetter);
         addActionWithResultOfSize_n(4);
         bean.setBatchSize(3);
         assertEquals(3, bean.getBatchSize());
@@ -101,6 +124,7 @@ public class SearchBeanTest extends MockObjectTestCase {
     @Test
     public void testMergedBatches() {
         bean = new SearchBean(executor, analyzer);
+        bean.setTimeoutSetter(timeoutSetter);
         addActionWithResultOfSize_n(3);
         addActionWithResultOfSize_n(1);
         bean.setBatchSize(5);
@@ -110,6 +134,7 @@ public class SearchBeanTest extends MockObjectTestCase {
     @Test
     public void testUnloaded() {
         bean = new SearchBean(executor, analyzer);
+        bean.setTimeoutSetter(timeoutSetter);
         addActionWithResultOfSize_n(1);
         bean.setReturnUnloaded(true);
         IObject i = bean.next();
@@ -119,6 +144,7 @@ public class SearchBeanTest extends MockObjectTestCase {
     @Test
     public void testResetDefaults() {
         bean = new SearchBean(executor, analyzer);
+        bean.setTimeoutSetter(timeoutSetter);
         bean.setBatchSize(4);
         bean.setCaseSensitive(false);
         bean.setMergedBatches(true);
@@ -131,6 +157,7 @@ public class SearchBeanTest extends MockObjectTestCase {
     @Test
     public void testClearingQueries() {
         bean = new SearchBean(executor, analyzer);
+        bean.setTimeoutSetter(timeoutSetter);
         bean.onlyType(Image.class);
         bean.byFullText("a");
         assertTrue(bean.activeQueries() == 1);
@@ -153,6 +180,7 @@ public class SearchBeanTest extends MockObjectTestCase {
     @Test
     public void testCanSearchForObjectsWhichArentAnnotated() {
         bean = new SearchBean(executor, analyzer);
+        bean.setTimeoutSetter(timeoutSetter);
         bean.onlyAnnotatedWith((java.lang.Class[]) null);
     }
 


### PR DESCRIPTION
Addresses [[trello] Hibernate Query.setTimeout should be configurable](https://trello.com/c/xcgIZjcN/144-hibernate-querysettimeout-should-be-configurable) by adding properties,
```
bin/omero config set omero.query.timeout 20
bin/omero config set omero.query.timeout.admin 200
```

The default timeout is set to over fifteen minutes for all users to avoid breaking current demanding workloads. However, it is expected that it could be appopriate to set the value much lower on the read-only servers that face public IDR users.

Including in `logback.xml`,
```xml
<logger name="ome.services.util.TimeoutSetter" level="DEBUG"/>
```
allows more of the activity to be monitored in the server logs.