### PR TITLE
IObject may be declaring interface in model object glossary.

### DIFF
--- a/src/main/java/ome/services/graphs/GraphPathBean.java
+++ b/src/main/java/ome/services/graphs/GraphPathBean.java
@@ -177,7 +177,7 @@ public class GraphPathBean extends OnContextRefreshedEventListener {
                     interfaceForProperty = interfaceFrom;
                 }
                 for (final Class<?> newInterface : interfaceFrom.getInterfaces()) {
-                    if (newInterface != IObject.class && IObject.class.isAssignableFrom(newInterface)) {
+                    if (IObject.class.isAssignableFrom(newInterface)) {
                         interfacesTo.add(newInterface.asSubclass(IObject.class));
                         classesBySimpleName.put(newInterface.getSimpleName(), newInterface.asSubclass(IObject.class));
                     }


### PR DESCRIPTION
Previously the "see" for interfaces would mention some sub-interface for `details.*` which was not as helpful as it could have been. Staged via https://github.com/openmicroscopy/ome-documentation/pull/1953.