### PR TITLE
Avoid reporting IObject links in model object glossary.

### DIFF
--- a/src/main/java/ome/services/graphs/GraphPathReport.java
+++ b/src/main/java/ome/services/graphs/GraphPathReport.java
@@ -249,7 +249,7 @@ public class GraphPathReport {
                 }
                 if (!declarerName.equals(className)) {
                     out.write(" from " + linkTo(getSimpleName(declarerName)));
-                } else {
+                } else if (!propertyName.startsWith("details.")) {
                     final String interfaceName = model.getInterfaceImplemented(className, propertyName);
                     if (interfaceName != null) {
                         out.write(", see " + linkToJavadoc(interfaceName));


### PR DESCRIPTION
`GraphPathReport` does *not* currently generate the current https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ws/src/omero/_build/html/developers/Model/EveryObject.html page. This PR is a minimal adjustment to restore previous behavior. To confirm, configure a local merge server then try something like,
```
java -cp lib/server/\* `bin/omero config get | awk '{print"-D"$1}'` ome.services.graphs.GraphPathReport /tmp/EveryObject.rst
```
and compare with the existing `omero/developers/Model/EveryObject.rst`.

Perhaps the Spring upgrade changed something in `org.springframework.beans.*` to, say, handle nested properties, thus newly catching the `IObject.details.*` ones? No other side-effects have yet become apparent so opting for a minimal fix for now.