### PR TITLE
Remove ignored max clause count for search bean.

### DIFF
--- a/src/main/java/ome/services/SearchBean.java
+++ b/src/main/java/ome/services/SearchBean.java
@@ -64,8 +64,6 @@ public class SearchBean extends AbstractStatefulBean implements Search {
 
     private/* final */transient Class<? extends Analyzer> analyzer;
 
-    private/* final */transient Integer maxClauseCount;
-
     public SearchBean(Executor executor, Class<? extends Analyzer> analyzer) {
         this.executor = executor;
         this.analyzer = analyzer;
@@ -101,8 +99,9 @@ public class SearchBean extends AbstractStatefulBean implements Search {
     /**
      * Injector used by Spring.
      */
+    @Deprecated
     public void setMaxClauseCount(Integer maxClauseCount) {
-        this.maxClauseCount = maxClauseCount;
+        /* ignored */
     }
 
     // Lifecycle methods

--- a/src/main/resources/ome/services/service-ome.api.Search.xml
+++ b/src/main/resources/ome/services/service-ome.api.Search.xml
@@ -25,7 +25,6 @@
         class="ome.services.SearchBean" scope="prototype">
      <property name="executor" ref="executor"/>
      <property name="analyzer" value="${omero.search.analyzer}"/>
-     <property name="maxClauseCount" value="${omero.search.maxclause}"/>
   </bean>
 
   <bean id="managed-ome.api.Search" parent="selfManagingService" scope="prototype">

--- a/src/main/resources/omero-server.properties
+++ b/src/main/resources/omero-server.properties
@@ -231,9 +231,6 @@ omero.search.reporting_loops=100
 # Analyzer used both index and to parse queries
 omero.search.analyzer=ome.services.fulltext.FullTextAnalyzer
 
-# Maximum number of OR-clauses to which a single search can expand
-omero.search.maxclause=4096
-
 # Maximum file size for text indexing (bytes)
 # If a file larger than this is attached, e.g. to an image, the indexer will
 # simply ignore the contents of the file when creating the search index.


### PR DESCRIPTION
Removes the `omero.search.maxclause` property from the server because nothing acts on it. If this PR is merged then mention of the property should be removed from https://docs.openmicroscopy.org/omero/5.4.10/developers/Modules/Search.html#leading-wildcard-searches.