### PR TITLE
Build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,10 +81,6 @@ test {
     }
 }
 
-clean {
-    delete generatedDir
-}
-
 if (slice.iceVersion.contains("3.7")) {
     dependencies {
         api "com.zeroc:ice:3.7.2"

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ java {
 ext {
     //the database type: must match the version set in omero-model
     databaseType = "psql"
-    generatedDir = "src/${databaseType}"
+    generatedDir = "build/${databaseType}"
 }
 
 dependencies {


### PR DESCRIPTION
Do not use the default setup so that nothing is generated under ``src``

To test:

* if you have previously done a build, make sure that there is no folder ``psql`` under ``src``. Delete it if there is one
* run ``gradle build``, check that ``psql`` is created under ``build`` and not ``src``