### PR TITLE
Have graph path report reference decoupled Javadoc.

### DIFF
--- a/src/main/java/ome/services/graphs/GraphPathReport.java
+++ b/src/main/java/ome/services/graphs/GraphPathReport.java
@@ -131,7 +131,7 @@ public class GraphPathReport {
      */
     private static String linkToJavadoc(String className) {
         final StringBuffer sb = new StringBuffer();
-        sb.append(":javadoc:");
+        sb.append(":javadoc_model:");
         sb.append('`');
         sb.append(getSimpleName(className));
         sb.append(' ');


### PR DESCRIPTION
See https://trello.com/c/YhO2AvYC/149-point-model-glossary-to-javadoc and openmicroscopy/ome-documentation#1955.

Originally done in https://github.com/ome/omero-server/pull/42 but the commit had to be reverted
cc @mtbc 