### PR TITLE
Upgrade Javassist for Java 11 compatibility.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
         implementation 'org.postgresql:postgresql:42.2.1'
     }
     // Used by hibernate, see: https://stackoverflow.com/a/14365438
-    implementation("org.javassist:javassist:3.22.0-GA")
+    implementation("org.javassist:javassist:3.25.0-GA")
 
     // API monitoring thing: http://jamonapi.sourceforge.net
     implementation("com.jamonapi:jamon:2.81")


### PR DESCRIPTION
Fixes the problem described at https://github.com/openmicroscopy/ome-documentation/pull/1972. Check that OMERO.server works fine on a Java 11 system.