### PR TITLE
flushToIndexes() after full-text indexer writes to indices.

### DIFF
--- a/src/main/java/ome/services/fulltext/FullTextIndexer2.java
+++ b/src/main/java/ome/services/fulltext/FullTextIndexer2.java
@@ -549,6 +549,7 @@ public class FullTextIndexer2 {
                     }
                 }
             }
+            fullTextSession.flushToIndexes();
             transaction.commit();
             toIndex.clear();
         } catch (UnresolvableObjectException uoe) {
@@ -622,6 +623,7 @@ public class FullTextIndexer2 {
                     purgeCounts.put(entityClass, entityIds.size() + (count == null ? 0 : count));
                 }
             }
+            fullTextSession.flushToIndexes();
             transaction.commit();
             toPurge.clear();
         } catch (UnresolvableObjectException uoe) {
@@ -715,6 +717,7 @@ public class FullTextIndexer2 {
                     }
                 }
             }
+            fullTextSession.flushToIndexes();
             transaction.commit();
         } finally {
             session.close();


### PR DESCRIPTION
`Session.setFlushMode(FlushMode.COMMIT)` may not always suffice so now call `FullTextSession.flushToIndexes()` before every `Transaction.commit()`.

--exclude because I don't believe it makes any difference