### PR TITLE
Full text additions

### DIFF
--- a/src/main/java/ome/services/fulltext/BridgeHelper.java
+++ b/src/main/java/ome/services/fulltext/BridgeHelper.java
@@ -133,7 +133,7 @@ public abstract class BridgeHelper implements FieldBridge,
      *            this value is null, then the "value" will only be added to the
      *            {@link #COMBINED} field.
      * @param value
-     *            {@link IEnum} whose {@link IEnum#getValue()} method will be alled.
+     *            {@link IEnum} whose {@link IEnum#getValue()} method will be called.
      *            If null, then this is a no-op.
      * @param opts
      *            LuceneOptions, passed in from the runtime. If overriding on

--- a/src/main/java/ome/services/fulltext/BridgeHelper.java
+++ b/src/main/java/ome/services/fulltext/BridgeHelper.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import ome.conditions.ApiUsageException;
 import ome.io.nio.OriginalFilesService;
+import ome.model.IEnum;
 import ome.model.IObject;
 import ome.model.core.OriginalFile;
 import ome.services.messages.ReindexMessage;
@@ -95,6 +96,66 @@ public abstract class BridgeHelper implements FieldBridge,
      * {@link #COMBINED} cases using a {@link StringReader} to allow Lucene to
      * tokenize the {@link String}.
      * 
+     * @param d
+     *            Document as passed to the set method. Do not modify.
+     * @param field
+     *            Field name which probably <em/>should</em> be modified. If
+     *            this value is null, then the "value" will only be added to the
+     *            {@link #COMBINED} field.
+     * @param value
+     *            Value which has been parsed out for this field. If null, then
+     *            this is a no-op.
+     * @param opts
+     *            LuceneOptions, passed in from the runtime. If overriding on
+     *            the interface values is required, see {@link SimpleLuceneOptions}
+     */
+    protected void addIfNotNull(Document d, String field, String value, LuceneOptions opts) {
+        if (value != null) {
+            add(d, field, value, opts);
+        }
+    }
+
+    /**
+     * Helper method which takes the parameters from the
+     * {@link #set(String, Object, Document, LuceneOptions)}
+     * method (possibly modified) as well as the {@link IEnum} value
+     * which should be added to the index, and adds two fields. One with the
+     * given field name and another to the {@link #COMBINED} field which is the
+     * default search provided to users. In addition to storing the value as is,
+     * another {@link Field} will be added for both the named and
+     * {@link #COMBINED} cases using a {@link StringReader} to allow Lucene to
+     * tokenize the {@link String}.
+     *
+     * @param d
+     *            Document as passed to the set method. Do not modify.
+     * @param field
+     *            Field name which probably <em/>should</em> be modified. If
+     *            this value is null, then the "value" will only be added to the
+     *            {@link #COMBINED} field.
+     * @param value
+     *            {@link IEnum} whose {@link IEnum#getValue()} method will be alled.
+     *            If null, then this is a no-op.
+     * @param opts
+     *            LuceneOptions, passed in from the runtime. If overriding on
+     *            the interface values is required, see {@link SimpleLuceneOptions}
+     */
+    protected void addEnumIfNotNull(Document d, String field, IEnum value, LuceneOptions opts) {
+        if (value != null) {
+            add(d, field, value.getValue(), opts);
+        }
+    }
+
+    /**
+     * Helper method which takes the parameters from the
+     * {@link #set(String, Object, Document, LuceneOptions)}
+     * method (possibly modified) as well as the parsed {@link String} value
+     * which should be added to the index, and adds two fields. One with the
+     * given field name and another to the {@link #COMBINED} field which is the
+     * default search provided to users. In addition to storing the value as is,
+     * another {@link Field} will be added for both the named and
+     * {@link #COMBINED} cases using a {@link StringReader} to allow Lucene to
+     * tokenize the {@link String}.
+     *
      * @param d
      *            Document as passed to the set method. Do not modify.
      * @param field

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -293,7 +293,7 @@ public class FullTextBridge extends BridgeHelper {
                 addEnumIfNotNull(document, "channel.mode", logical.getMode(), opts);
                 addEnumIfNotNull(document, "channel.photometricInterpretation",
                         logical.getPhotometricInterpretation(), opts);
-                // TODO: how to represent Length
+                // Note: length items omitted due to difficulty of handling units
             }
         }
     }
@@ -405,8 +405,7 @@ public class FullTextBridge extends BridgeHelper {
                 }
                 add(document, "fileset.entry.clientPath", entry.getClientPath(), opts);
                 add(document, "fileset.entry.name", entry.getOriginalFile().getName(), opts);
-                // TODO: entry.hash? fileset.templatePrefix?
-                // TODO: update docs table
+                add(document, "fileset.templatePrefix", fileset.getTemplatePrefix(), opts);
             }
         }
     }

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -260,7 +260,13 @@ public class FullTextBridge extends BridgeHelper {
                                 final Document document, final LuceneOptions opts) {
         if (object instanceof Image) {
             final Image image = (Image) object;
+            if (image.sizeOfPixels() == 0) {
+                return;
+            }
             final Pixels pixels = image.getPrimaryPixels();
+            if (pixels == null) {
+                return;
+            }
             final Iterator<Channel> channelIterator = pixels.iterateChannels();
             while (channelIterator.hasNext()) {
                 final Channel channel = channelIterator.next();
@@ -371,6 +377,9 @@ public class FullTextBridge extends BridgeHelper {
         if (object instanceof Image) {
             final Image image = (Image) object;
             final Fileset fileset = image.getFileset();
+            if (fileset == null) {
+                return;
+            }
             final Iterator<FilesetEntry> entryIterator = fileset.iterateUsedFiles();
             while (entryIterator.hasNext()) {
                 final FilesetEntry entry = entryIterator.next();

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -278,15 +278,19 @@ public class FullTextBridge extends BridgeHelper {
             final Iterator<Channel> channelIterator = pixels.iterateChannels();
             while (channelIterator.hasNext()) {
                 final Channel channel = channelIterator.next();
-                final LogicalChannel logical = channel.getLogicalChannel();
-                if (logical != null) {
-                    addIfNotNull(document, "channel.name", logical.getName(), opts);
-                    addIfNotNull(document, "channel.fluor", logical.getFluor(), opts);
-                    addEnumIfNotNull(document, "channel.mode", logical.getMode(), opts);
-                    addEnumIfNotNull(document, "channel.photometricInterpretation",
-                            logical.getPhotometricInterpretation(), opts);
-                    // TODO: how to represent Length
+                if (channel == null) {
+                    continue;
                 }
+                final LogicalChannel logical = channel.getLogicalChannel();
+                if (logical == null) {
+                    continue;
+                }
+                addIfNotNull(document, "channel.name", logical.getName(), opts);
+                addIfNotNull(document, "channel.fluor", logical.getFluor(), opts);
+                addEnumIfNotNull(document, "channel.mode", logical.getMode(), opts);
+                addEnumIfNotNull(document, "channel.photometricInterpretation",
+                        logical.getPhotometricInterpretation(), opts);
+                // TODO: how to represent Length
             }
         }
     }
@@ -393,6 +397,9 @@ public class FullTextBridge extends BridgeHelper {
             final Iterator<FilesetEntry> entryIterator = fileset.iterateUsedFiles();
             while (entryIterator.hasNext()) {
                 final FilesetEntry entry = entryIterator.next();
+                if (entry == null) {
+                    continue;
+                }
                 add(document, "fileset.entry.clientPath", entry.getClientPath(), opts);
                 add(document, "fileset.entry.name", entry.getOriginalFile().getName(), opts);
                 // TODO: entry.hash? fileset.templatePrefix?

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -5,11 +5,6 @@
 
 package ome.services.fulltext;
 
-import java.io.Reader;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
 import ome.io.nio.OriginalFilesService;
 import ome.model.IAnnotated;
 import ome.model.ILink;
@@ -20,10 +15,14 @@ import ome.model.annotations.FileAnnotation;
 import ome.model.annotations.LongAnnotation;
 import ome.model.annotations.MapAnnotation;
 import ome.model.annotations.TagAnnotation;
-import ome.model.annotations.TextAnnotation;
 import ome.model.annotations.TermAnnotation;
+import ome.model.annotations.TextAnnotation;
 import ome.model.containers.Folder;
-import ome.model.core.*;
+import ome.model.core.Channel;
+import ome.model.core.Image;
+import ome.model.core.LogicalChannel;
+import ome.model.core.OriginalFile;
+import ome.model.core.Pixels;
 import ome.model.fs.Fileset;
 import ome.model.fs.FilesetEntry;
 import ome.model.internal.Details;
@@ -35,7 +34,6 @@ import ome.model.meta.ExperimenterGroup;
 import ome.model.roi.Roi;
 import ome.util.DetailsFieldBridge;
 import ome.util.Utils;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Index;
@@ -44,6 +42,11 @@ import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.LuceneOptions;
 import org.hibernate.search.bridge.builtin.DateBridge;
+
+import java.io.Reader;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Primary definition of what will be indexed via Hibernate Search. This class

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -114,7 +114,10 @@ public class FullTextBridge extends BridgeHelper {
      * method which calls
      * {@link #set_file(String, IObject, Document, LuceneOptions)}
      * {@link #set_annotations(String, IObject, Document, LuceneOptions)},
+     * {@link #set_acquisition(String, IObject, Document, LuceneOptions)},
      * {@link #set_details(String, IObject, Document, LuceneOptions)},
+     * {@link #set_fileset(String, IObject, Document, LuceneOptions)},
+     * {@link #set_folders(String, IObject, Document, LuceneOptions)},
      * and finally
      * {@link #set_custom(String, IObject, Document, LuceneOptions)}.
      * as well as all {@link Annotation annotations}.
@@ -143,7 +146,7 @@ public class FullTextBridge extends BridgeHelper {
      * to get a {@link Reader} for the given
      * file which is then passed to
      * {@link #addContents(Document, String, OriginalFile, OriginalFilesService, Map, LuceneOptions)}
-     * using the field name "file".
+     * using the field name "file.contents".
      *
      * @param name
      * @param object
@@ -249,7 +252,12 @@ public class FullTextBridge extends BridgeHelper {
     }
 
     /**
-     * Walks the acquisition related metadata including channel names.
+     * Walks the acquisition related metadata including channel names. This includes:
+     *
+     * - channel.name
+     * - channel.fluor
+     * - channel.mode
+     * - channel.photometricInterpretation
      *
      * @param name
      * @param object
@@ -369,8 +377,10 @@ public class FullTextBridge extends BridgeHelper {
     }
 
     /**
-     * Walks the {@link Fileset} instances attached to and Image
-     * so users can use the original clientpath for search.
+     * Walks the {@link Fileset} instances attached to an Image. Fields that are added include:
+     *
+     * - fileset.entry.clientPath
+     * - fileset.entry.name
      */
     public void set_fileset(final String name, final IObject object,
                             final Document document, final LuceneOptions opts) {

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -266,11 +266,11 @@ public class FullTextBridge extends BridgeHelper {
                 final Channel channel = channelIterator.next();
                 final LogicalChannel logical = channel.getLogicalChannel();
                 if (logical != null) {
-                    add(document, "channel.name", logical.getName(), opts);
-                    add(document, "channel.fluor", logical.getFluor(), opts);
-                    add(document, "channel.mode", logical.getMode().getValue(), opts);
-                    add(document, "channel.photoetricInterpretation",
-                            logical.getPhotometricInterpretation().getValue(), opts);
+                    addIfNotNull(document, "channel.name", logical.getName(), opts);
+                    addIfNotNull(document, "channel.fluor", logical.getFluor(), opts);
+                    addEnumIfNotNull(document, "channel.mode", logical.getMode(), opts);
+                    addEnumIfNotNull(document, "channel.photoetricInterpretation",
+                            logical.getPhotometricInterpretation(), opts);
                     // TODO: how to represent Length
                 }
             }

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -275,7 +275,7 @@ public class FullTextBridge extends BridgeHelper {
                     addIfNotNull(document, "channel.name", logical.getName(), opts);
                     addIfNotNull(document, "channel.fluor", logical.getFluor(), opts);
                     addEnumIfNotNull(document, "channel.mode", logical.getMode(), opts);
-                    addEnumIfNotNull(document, "channel.photoetricInterpretation",
+                    addEnumIfNotNull(document, "channel.photometricInterpretation",
                             logical.getPhotometricInterpretation(), opts);
                     // TODO: how to represent Length
                 }

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -23,8 +23,7 @@ import ome.model.annotations.TagAnnotation;
 import ome.model.annotations.TextAnnotation;
 import ome.model.annotations.TermAnnotation;
 import ome.model.containers.Folder;
-import ome.model.core.Image;
-import ome.model.core.OriginalFile;
+import ome.model.core.*;
 import ome.model.fs.Fileset;
 import ome.model.fs.FilesetEntry;
 import ome.model.internal.Details;
@@ -131,6 +130,7 @@ public class FullTextBridge extends BridgeHelper {
 
         set_file(name, object, document, opts);
         set_annotations(name, object, document, opts);
+        set_acquisition(name, object, document, opts);
         set_details(name, object, document, opts);
         set_fileset(name, object, document, opts);
         set_folders(name, object, document, opts);
@@ -245,6 +245,35 @@ public class FullTextBridge extends BridgeHelper {
         } else if (object instanceof MapAnnotation) {
             MapAnnotation mapAnnotation = (MapAnnotation) object;
             handleMapAnnotation(document, opts, mapAnnotation);
+        }
+    }
+
+    /**
+     * Walks the acquisition related metadata including channel names.
+     *
+     * @param name
+     * @param object
+     * @param document
+     * @param opts
+     */
+    public void set_acquisition(final String name, final IObject object,
+                                final Document document, final LuceneOptions opts) {
+        if (object instanceof Image) {
+            final Image image = (Image) object;
+            final Pixels pixels = image.getPrimaryPixels();
+            final Iterator<Channel> channelIterator = pixels.iterateChannels();
+            while (channelIterator.hasNext()) {
+                final Channel channel = channelIterator.next();
+                final LogicalChannel logical = channel.getLogicalChannel();
+                if (logical != null) {
+                    add(document, "channel.name", logical.getName(), opts);
+                    add(document, "channel.fluor", logical.getFluor(), opts);
+                    add(document, "channel.mode", logical.getMode().getValue(), opts);
+                    add(document, "channel.photoetricInterpretation",
+                            logical.getPhotometricInterpretation().getValue(), opts);
+                    // TODO: how to represent Length
+                }
+            }
         }
     }
 

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -25,6 +25,8 @@ import ome.model.annotations.TermAnnotation;
 import ome.model.containers.Folder;
 import ome.model.core.Image;
 import ome.model.core.OriginalFile;
+import ome.model.fs.Fileset;
+import ome.model.fs.FilesetEntry;
 import ome.model.internal.Details;
 import ome.model.internal.NamedValue;
 import ome.model.internal.Permissions;
@@ -130,6 +132,7 @@ public class FullTextBridge extends BridgeHelper {
         set_file(name, object, document, opts);
         set_annotations(name, object, document, opts);
         set_details(name, object, document, opts);
+        set_fileset(name, object, document, opts);
         set_folders(name, object, document, opts);
         set_custom(name, object, document, opts);
 
@@ -326,6 +329,26 @@ public class FullTextBridge extends BridgeHelper {
                     final Folder folder = folderIterator.next();
                     add(document, "roi.folder.name", folder.getName(), opts);
                 }
+            }
+        }
+    }
+
+    /**
+     * Walks the {@link Fileset} instances attached to and Image
+     * so users can use the original clientpath for search.
+     */
+    public void set_fileset(final String name, final IObject object,
+                            final Document document, final LuceneOptions opts) {
+        if (object instanceof Image) {
+            final Image image = (Image) object;
+            final Fileset fileset = image.getFileset();
+            final Iterator<FilesetEntry> entryIterator = fileset.iterateUsedFiles();
+            while (entryIterator.hasNext()) {
+                final FilesetEntry entry = entryIterator.next();
+                add(document, "fileset.entry.clientPath", entry.getClientPath(), opts);
+                add(document, "fileset.entry.name", entry.getOriginalFile().getName(), opts);
+                // TODO: entry.hash? fileset.templatePrefix?
+                // TODO: update docs table
             }
         }
     }


### PR DESCRIPTION
As requested recently by @olatarkowska and @sukunis, the FullTextBridge could index a number of additional properties. This PR begins that processing by indexing both `Filesets` as well as `(Logical)Channels` for Images.

cc: @mtbc @jburel @dominikl @pwalczysko @will-moore (the search interested)

Simple clientPath test:
```
mkdir /tmp/abc
touch /tmp/abc/def.fake
bin/omero import /tmp/abc/def.fake
bin/omero search Image abc
```