### PR TITLE
Re-work exception handling on LDAP lookups (fix #55)

### DIFF
--- a/src/main/java/ome/logic/LdapImpl.java
+++ b/src/main/java/ome/logic/LdapImpl.java
@@ -197,37 +197,54 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
         List<Experimenter> p = ldap.search("", filter.encode(),
                 mapper.getControls(), mapper);
 
-        if (p.size() == 1 && p.get(0) != null) {
-            Experimenter e = p.get(0);
-            if (provider.isIgnoreCaseLookup()) {
-                if (e.getOmeName().equalsIgnoreCase(username)) {
-                    return p.get(0);
-                }
-            } else {
-                if (e.getOmeName().equals(username)) {
-                    return p.get(0);
-                }
-            }
+        if (p.size() != 1) {
+            throw new ApiUsageException(
+                    "Cannot find unique user DistinguishedName: found=" + p.size());
         }
-        throw new ApiUsageException(
-                "Cannot find unique user DistinguishedName: found=" + p.size());
+
+        if (p.get(0) == null) {
+            throw new ApiUsageException(
+                    "Returned Experiment is null!");
+        }
+
+        final boolean ignoreCase = provider.isIgnoreCaseLookup();
+        final Experimenter e = p.get(0);
+        if (ignoreCase && e.getOmeName().equalsIgnoreCase(username)) {
+                return p.get(0);
+        } else if (!ignoreCase && e.getOmeName().equals(username)) {
+                return p.get(0);
+        }
+        throw new ApiUsageException(String.format(
+                "omeName(%s) != username(%s). ignoreCase=%s",
+                    e.getOmeName(), username, ignoreCase));
     }
 
     @SuppressWarnings("unchecked")
     private ExperimenterGroup mapGroupName(String groupname,
             GroupContextMapper mapper) {
+
         Filter filter = config.groupnameFilter(groupname);
         List<ExperimenterGroup> g = ldap.search("", filter.encode(),
                 mapper.getControls(), mapper);
 
-        if (g.size() == 1 && g.get(0) != null) {
-            ExperimenterGroup grp = g.get(0);
-            if (grp.getName().equals(groupname)) {
-                return g.get(0);
-            }
+        if (g.size() != 1) {
+            throw new ApiUsageException(
+                    "Cannot find unique group DistinguishedName: found=" + g.size());
         }
-        throw new ApiUsageException(
-                "Cannot find unique group DistinguishedName: found=" + g.size());
+
+        if (g.get(0) == null) {
+            throw new ApiUsageException(
+                    "Returned Group is null!");
+        }
+
+        final ExperimenterGroup grp = g.get(0);
+        if (grp.getName().equals(groupname)) {
+            return g.get(0);
+        }
+
+        throw new ApiUsageException(String.format(
+                "name(%s) != groupname(%s)",
+                grp.getName(), groupname));
     }
 
     @RolesAllowed("system")

--- a/src/main/java/ome/logic/LdapImpl.java
+++ b/src/main/java/ome/logic/LdapImpl.java
@@ -198,13 +198,13 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
                 mapper.getControls(), mapper);
 
         if (p.size() != 1) {
-            throw new ApiUsageException(
-                    "Cannot find unique user DistinguishedName: found=" + p.size());
+            throw new ApiUsageException(String.format(
+                    "Cannot find unique user DistinguishedName: found=%s (%s)", p.size(), username));
         }
 
         if (p.get(0) == null) {
-            throw new ApiUsageException(
-                    "Returned Experimenter is null!");
+            throw new ApiUsageException(String.format(
+                    "Returned Experimenter is null! (%s)", username));
         }
 
         final boolean ignoreCase = provider.isIgnoreCaseLookup();
@@ -228,13 +228,13 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
                 mapper.getControls(), mapper);
 
         if (g.size() != 1) {
-            throw new ApiUsageException(
-                    "Cannot find unique group DistinguishedName: found=" + g.size());
+            throw new ApiUsageException(String.format(
+                    "Cannot find unique group DistinguishedName: found=%s (%s)", g.size(), groupname));
         }
 
         if (g.get(0) == null) {
-            throw new ApiUsageException(
-                    "Returned Group is null!");
+            throw new ApiUsageException(String.format(
+                    "Returned Group is null! (%s)", groupname));
         }
 
         final ExperimenterGroup grp = g.get(0);

--- a/src/main/java/ome/logic/LdapImpl.java
+++ b/src/main/java/ome/logic/LdapImpl.java
@@ -204,7 +204,7 @@ public class LdapImpl extends AbstractLevel2Service implements ILdap,
 
         if (p.get(0) == null) {
             throw new ApiUsageException(
-                    "Returned Experiment is null!");
+                    "Returned Experimenter is null!");
         }
 
         final boolean ignoreCase = provider.isIgnoreCaseLookup();


### PR DESCRIPTION
Rather than use the same "Cannot find unique distinguished"
exception for all code paths, throw early with a different
message for each case.

cc: @stick @mtbc 