### PR TITLE
Have NPE from FieldBridge on indexing not stall indexer.

### DIFF
--- a/src/main/java/ome/services/fulltext/FullTextIndexer2.java
+++ b/src/main/java/ome/services/fulltext/FullTextIndexer2.java
@@ -548,7 +548,16 @@ public class FullTextIndexer2 {
                     final Class<? extends IObject> entityClass = Hibernate.getClass(entity);
                     if (isIncluded(entityClass)) {
                         LOGGER.debug("indexing {}:{}", entityType, ((IObject) entity).getId());
-                        fullTextSession.index(entity);
+                        try {
+                            fullTextSession.index(entity);
+                        } catch (BridgeException be) {
+                            /* Handle buggy bridge implementation. */
+                            if (be.getCause() instanceof NullPointerException) {
+                                LOGGER.warn("failed to index {}:{}", entityType, ((IObject) entity).getId(), be.getCause());
+                            } else {
+                                throw be;
+                            }
+                        }
                     } else {
                         LOGGER.debug("skipping {}:{}", entityType, ((IObject) entity).getId());
                     }


### PR DESCRIPTION
This PR eases development of #57 by having the indexer tolerate NPEs from the field bridge. This PR falls short of fixing #59 adequately but that requires more effort.