### PR TITLE
Correct trivial typo in log message.

### DIFF
--- a/src/main/java/ome/services/ThumbnailBean.java
+++ b/src/main/java/ome/services/ThumbnailBean.java
@@ -1525,7 +1525,7 @@ public class ThumbnailBean extends AbstractLevel2Service
         catch (ConcurrencyException mpe)
         {
             inProgress = true;
-            log.info("ConcurrencyException on settingsSerice.resetDefaults");
+            log.info("ConcurrencyException on settingsService.resetDefaults");
         }
     }
 


### PR DESCRIPTION
Corrects typo and ends source file with EOL, see diff.