### PR TITLE
Add default connect and read timeouts of 5 seconds for JNDI/LDAP

### DIFF
--- a/src/main/resources/ome/services/service-ome.api.ILdap.xml
+++ b/src/main/resources/ome/services/service-ome.api.ILdap.xml
@@ -81,6 +81,12 @@
 		<property name="referral" value="${omero.ldap.referral}" />
 		<property name="dirObjectFactory"
 			value="org.springframework.ldap.core.support.DefaultDirObjectFactory" />
+        <property name="baseEnvironmentProperties">
+			<entry key="com.sun.jndi.ldap.connect.timeout"
+			       value="${omero.ldap.connect_timeout}" />
+			<entry key="com.sun.jndi.ldap.read.timeout"
+			       value="${omero.ldap.read_timeout}" />
+        </property>
 	</bean>
 
 </beans>

--- a/src/main/resources/ome/services/service-ome.api.ILdap.xml
+++ b/src/main/resources/ome/services/service-ome.api.ILdap.xml
@@ -81,12 +81,14 @@
 		<property name="referral" value="${omero.ldap.referral}" />
 		<property name="dirObjectFactory"
 			value="org.springframework.ldap.core.support.DefaultDirObjectFactory" />
-        <property name="baseEnvironmentProperties">
-			<entry key="com.sun.jndi.ldap.connect.timeout"
-			       value="${omero.ldap.connect_timeout}" />
-			<entry key="com.sun.jndi.ldap.read.timeout"
-			       value="${omero.ldap.read_timeout}" />
-        </property>
+		<property name="baseEnvironmentProperties">
+			<map>
+				<entry key="com.sun.jndi.ldap.connect.timeout"
+				       value="${omero.ldap.connect_timeout}" />
+				<entry key="com.sun.jndi.ldap.read.timeout"
+				       value="${omero.ldap.read_timeout}" />
+			</map>
+		</property>
 	</bean>
 
 </beans>

--- a/src/main/resources/omero-server.properties
+++ b/src/main/resources/omero-server.properties
@@ -443,5 +443,42 @@ omero.ldap.new_user_group=default
 # 'default' and only potentially by ``:bean:``.
 omero.ldap.new_user_group_owner=
 
+# Sets ``com.sun.jndi.ldap.connect.timeout`` on the Spring LDAP
+# default security context source environment.  The context source
+# is responsible for interacting with JNDI/LDAP.
+#
+# This timeout is specified in milliseconds and controls the amount of
+# time JNDI/LDAP will wait for a connection to be established.
+#
+# A timeout less than or equal to zero means that no timeout will be
+# observed and that the OMERO server will wait indefinitely for LDAP
+# connections to be established.  Such a timeout should be used with
+# extreme caution as connectivity issues may then cause your server to
+# no longer be able to create new sessions.
+#
+# For more information on what this JNDI/LDAP property does, see
+# https://docs.oracle.com/javase/tutorial/jndi/newstuff/readtimeout.html
+omero.ldap.connect_timeout=5000
+
+# Sets ``com.sun.jndi.ldap.read.timeout`` on the Spring LDAP
+# default security context source environment.  The context source
+# is responsible for interacting with JNDI/LDAP.
+#
+# This timeout is specified in milliseconds and controls the amount of
+# time JNDI/LDAP will wait for a response from the LDAP server.  When
+# connecting to a server using SSL this timeout also applies to the
+# SSL handshake process.
+#
+# A timeout less than or equal to zero means that no timeout will be
+# observed and that the OMERO server will wait indefinitely for LDAP
+# replies.  Such a timeout should be used with extreme caution,
+# especially when using SSL and/or without a connection pool, as
+# connectivity issues may then cause your server to no longer be
+# able to create new sessions.
+#
+# For more information on what this JNDI/LDAP property does, see
+# https://docs.oracle.com/javase/tutorial/jndi/newstuff/readtimeout.html
+omero.ldap.read_timeout=5000
+
 # Value dynamically set during the build
 omero.version=

--- a/src/main/resources/omero-server.properties
+++ b/src/main/resources/omero-server.properties
@@ -457,7 +457,7 @@ omero.ldap.new_user_group_owner=
 # no longer be able to create new sessions.
 #
 # For more information on what this JNDI/LDAP property does, see
-# https://docs.oracle.com/javase/tutorial/jndi/newstuff/readtimeout.html
+# https://docs.oracle.com/javase/jndi/tutorial/ldap/connect/create.html
 omero.ldap.connect_timeout=5000
 
 # Sets ``com.sun.jndi.ldap.read.timeout`` on the Spring LDAP

--- a/src/test/java/ome/server/utests/LoadBeanDefinitionsTest.java
+++ b/src/test/java/ome/server/utests/LoadBeanDefinitionsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019 Glencoe Software, Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.server.utests;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.testng.annotations.Test;
+
+/**
+ * Test to ensure that the beans that comprise "ome.server" can be loaded.
+ * Should catch any issues with Spring XML formatting.
+ *
+ * @author Chris Allan
+ * @since 5.5.5
+ */
+public class LoadBeanDefinitionsTest {
+
+    @Test
+    public void testLoadBeanDefinitions() {
+        DefaultListableBeanFactory factory =
+                new DefaultListableBeanFactory();
+        XmlBeanDefinitionReader reader =
+                new XmlBeanDefinitionReader(factory);
+        reader.loadBeanDefinitions(
+            "classpath:ome/config.xml",
+            "classpath:ome/services/messaging.xml",
+            "classpath:ome/services/checksum.xml",
+            "classpath:ome/services/datalayer.xml",
+            "classpath*:ome/services/db-*.xml",
+            "classpath:ome/services/sec-primitives.xml",
+            "classpath:ome/services/hibernate.xml",
+            "classpath:ome/services/services.xml",
+            "classpath*:ome/services/service-*.xml",
+            "classpath:ome/services/sec-system.xml",
+            "classpath:ome/services/startup.xml"
+        );
+    }
+
+}


### PR DESCRIPTION
# Summary

Sets default timeouts for  JNDI/LDAP connect, read, and SSL handshake operations to 5 seconds and allows each type of timeout to be configured. The default timeout for these operations is `-1` causing the OMERO server to wait indefinitely. As a consequence LDAP server malaise (connectivity problems or actual LDAP server issues) may cause an OMERO server to behave like it is deadlocked.

# Investigation

We have been researching a set of lingering deadlock or deadlock like conditions across a few of our customers. One condition where we see such behaviour is under LDAP server malaise (connectivity problems or actual LDAP server issues). We have seen as many as 16 server threads at a time blocked communicating with the configured LDAP server. Under these conditions the OMERO server does not exhibit high CPU usage, excessive RAM usage, does not have a high number of open file handles, system load is low and the server is completely unresponsive. The symptoms are similar but do not completely overlap with this forum thread from Jun 2017:

 * https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=8297

An example stack trace from `jstack` follows:

```
"Thread-296898" #542667 daemon prio=5 os_prio=0 tid=0x00007fc461e02000 nid=0x6551 runnable [0x00007fc5e76f7000]
   java.lang.Thread.State: RUNNABLE
        at java.net.SocketInputStream.socketRead0(Native Method)
        at java.net.SocketInputStream.socketRead(SocketInputStream.java:116)
        at java.net.SocketInputStream.read(SocketInputStream.java:171)
        at java.net.SocketInputStream.read(SocketInputStream.java:141)
        at sun.security.ssl.InputRecord.readFully(InputRecord.java:465)
        at sun.security.ssl.InputRecord.read(InputRecord.java:503)
        at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:983)
        - locked <0x0000000681363110> (a java.lang.Object)
        at sun.security.ssl.SSLSocketImpl.readDataRecord(SSLSocketImpl.java:940)
        at sun.security.ssl.AppInputStream.read(AppInputStream.java:105)
        - locked <0x0000000681363678> (a sun.security.ssl.AppInputStream)
        at java.io.BufferedInputStream.fill(BufferedInputStream.java:246)
        at java.io.BufferedInputStream.read1(BufferedInputStream.java:286)
        at java.io.BufferedInputStream.read(BufferedInputStream.java:345)
        - locked <0x000000068136c770> (a java.io.BufferedInputStream)
        at com.sun.jndi.ldap.Connection.run(Connection.java:860)
        at java.lang.Thread.run(Thread.java:748)
```

This scenario was sporadic and very difficult to spontaneously trigger in production as in most cases we do not have access to the LDAP server itself and a simple server restart makes the problem go away nearly instantly. A running theory is that these blocked threads accumulate over time but we do not have the longitudinal data to completely support this.

Based on the aforementioned thread we attempted to reproduce the scenario in isolation by introducing `iptables` rules with the `DROP` target at various times to simulate the connectivity malaise and attempt to mitigate it with timeouts. We also researched other examples of these conditions in the wild and came up with three main socket/protocol conditions where a JNDI/LDAP thread can currently block:

1. Initial connection phase (causes the thread to block for 10s of seconds but is usually mitigated by default operating system socket connect timeouts; 20 seconds on Windows, 60 seconds on Linux)
1. SSL handshake phase (causes the thread to block indefinitely)
1. Waiting for response (causes the thread to block indefinitely)

Much to our surprise, many of the properties discussed in the aforementioned thread such as  `com.sun.jndi.ldap.connect.timeout`, `com.sun.jndi.ldap.read.timeout` and `com.sun.jndi.ldap.connect.pool.*` had no effect when specified as system properties on our test system. This lead to the creation of a small tool for attempting to instrument this particular code path in isolation, `omero-ldaptool`:

 * https://github.com/glencoesoftware/omero-ldaptool

Following code instrumentation and research we came to the following realizations:

1. `com.sun.jndi.ldap.connect.timeout` and `com.sun.jndi.ldap.read.timeout` **ARE NOT** system properties but rather JNDI/LDAP environment properties that must be provided to the directly. This process is detailed [here](https://docs.oracle.com/javase/tutorial/jndi/newstuff/readtimeout.html).
2. JNDI/LDAP connection pooling is not enabled by default when using SSL. As such any `com.sun.jndi.ldap.connect.pool.*` properties will have no effect with such configuration. The `com.sun.jndi.ldap.connect.pool.*` **ARE** system properties.
3. Pauses during the SSL handshake phase are unaffected by `com.sun.jndi.ldap.connect.timeout`
4. The default timeouts for connect and read are `-1` meaning that under any of the aforementioned socket/protocol conditions the thread performing the JNDI/LDAP operation can block **indefinitely**.

The difference in connection pooling behaviour between SSL and non-SSL LDAP server connections is particularly troubling and may actually deserve further follow-up and documentation.

we are using Spring LDAP rather than JNDI/LDAP directly and the connect as well as read timeouts must be specified on that very specific environment. Changes to the Spring XML configuration are required.

# Testing

In order to easily test the connection timeout, set your `omero.ldap.urls` to some non-existant server which will not respond with a TCP reset indicating that the port is closed. If you then attempt a login you should have a round trip time in the neighbourhood of what you have set `omero.ldap.connect_timeout` to be.

For testing read timeouts, you can set up netcat to listen on localhost and not reply with `nc -l -k 127.0.0.1 1389` or similar and then set your `omero.ldap.urls` to `ldap://localhost:1389`. This can also be repeated by using an `ldaps` URI to ensure that the timeout is also being triggered for SSL handshakes that take too long.

# References

 * https://docs.oracle.com/javase/tutorial/jndi/newstuff/readtimeout.html
 * https://docs.oracle.com/javase/jndi/tutorial/ldap/connect/config.html
 * https://github.com/glencoesoftware/omero-ldaptool
 * https://stackoverflow.com/questions/23887669/implementation-of-timeout-in-ldap

/cc @emilroz, @stick, @kkoz