### PR TITLE
Catch fewer exceptions in full-text indexer.

### DIFF
--- a/src/main/java/ome/services/fulltext/FullTextIndexer2.java
+++ b/src/main/java/ome/services/fulltext/FullTextIndexer2.java
@@ -45,12 +45,10 @@ import org.apache.commons.lang.StringUtils;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.Hibernate;
-import org.hibernate.HibernateException;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
-import org.hibernate.UnresolvableObjectException;
 import org.hibernate.jdbc.Work;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
@@ -161,8 +159,6 @@ public class FullTextIndexer2 {
         STARTUP(20),
         /* How long to wait to try to relock the field bridge. */
         FIELD_BRIDGE_CONTENTION(5),
-        /* How long to wait after failing to read data via Hibernate. */
-        HIBERNATE_QUERY_ERROR(10),
         /* How long to wait after finding nothing new to index. */
         NOTHING_NEW_TO_INDEX(2);
 
@@ -423,7 +419,6 @@ public class FullTextIndexer2 {
      */
     public void prepare() {
         final Session session = sessionFactory.openSession();
-        HibernateException hibernateQueryError = null;
         boolean isNothingNew = false;
         try {
             LOGGER.debug("adding any new REINDEX entries");
@@ -489,18 +484,11 @@ public class FullTextIndexer2 {
                 removeObsoleteEntries(toPurge, session);
             }
             transaction.rollback();
-        } catch (UnresolvableObjectException uoe) {
-            hibernateQueryError = uoe;
         } finally {
             session.close();
         }
         try {
-            if (hibernateQueryError != null) {
-                toIndex.clear();
-                toPurge.clear();
-                LOGGER.info("Hibernate query failed, aborting this indexer run", hibernateQueryError);
-                register(Step.PREPARE, Event.HIBERNATE_QUERY_ERROR);
-            } else if (!toIndex.isEmpty()) {
+            if (!toIndex.isEmpty()) {
                 register(Step.INDEX);
             } else if (!toPurge.isEmpty()) {
                 register(Step.PURGE);
@@ -543,7 +531,6 @@ public class FullTextIndexer2 {
         }
         final ParserSession parserSession = new ParserSession();
         final Session session = sessionFactory.openSession();
-        HibernateException hibernateQueryError = null;
         Throwable bridgeException = null;
         try {
             final FullTextSession fullTextSession = Search.getFullTextSession(session);
@@ -570,8 +557,6 @@ public class FullTextIndexer2 {
             }
             transaction.commit();
             toIndex.clear();
-        } catch (UnresolvableObjectException uoe) {
-            hibernateQueryError = uoe;
         } catch (BridgeException be) {
             bridgeException = be.getCause();
             LOGGER.info("bridge failed, will retry indexing", bridgeException);
@@ -581,12 +566,7 @@ public class FullTextIndexer2 {
             parserSession.closeParsedFiles();
         }
         try {
-            if (hibernateQueryError != null) {
-                toIndex.clear();
-                toPurge.clear();
-                LOGGER.info("Hibernate query failed, aborting this indexer run", hibernateQueryError);
-                register(Step.PREPARE, Event.HIBERNATE_QUERY_ERROR);
-            } else if (bridgeException != null) {
+            if (bridgeException != null) {
                 register(Step.INDEX_RETRY);
             } else if (!toPurge.isEmpty()) {
                 register(Step.PURGE);
@@ -616,7 +596,6 @@ public class FullTextIndexer2 {
         }
         final ParserSession parserSession = new ParserSession();
         final Session session = sessionFactory.openSession();
-        HibernateException hibernateQueryError = null;
         try {
             final FullTextSession fullTextSession = Search.getFullTextSession(session);
             fullTextSession.setCacheMode(CacheMode.IGNORE);
@@ -649,20 +628,13 @@ public class FullTextIndexer2 {
                 }
             }
             toIndex.clear();
-        } catch (UnresolvableObjectException uoe) {
-            hibernateQueryError = uoe;
         } finally {
             DetailsFieldBridge.unlock();
             session.close();
             parserSession.closeParsedFiles();
         }
         try {
-            if (hibernateQueryError != null) {
-                toIndex.clear();
-                toPurge.clear();
-                LOGGER.info("Hibernate query failed, aborting this indexer run", hibernateQueryError);
-                register(Step.PREPARE, Event.HIBERNATE_QUERY_ERROR);
-            } else if (!toPurge.isEmpty()) {
+            if (!toPurge.isEmpty()) {
                 register(Step.PURGE);
             } else {
                 register(Step.NOTE);
@@ -689,7 +661,6 @@ public class FullTextIndexer2 {
             return;
         }
         final Session session = sessionFactory.openSession();
-        HibernateException hibernateQueryError = null;
         try {
             final FullTextSession fullTextSession = Search.getFullTextSession(session);
             fullTextSession.setCacheMode(CacheMode.IGNORE);
@@ -716,27 +687,12 @@ public class FullTextIndexer2 {
             }
             transaction.commit();
             toPurge.clear();
-        } catch (UnresolvableObjectException uoe) {
-            hibernateQueryError = uoe;
-        } catch (BridgeException be) {
-            if (be.getCause() instanceof UnresolvableObjectException) {
-                hibernateQueryError = (UnresolvableObjectException) be.getCause();
-            } else {
-                throw be;
-            }
         } finally {
             DetailsFieldBridge.unlock();
             session.close();
         }
         try {
-            if (hibernateQueryError != null) {
-                toIndex.clear();
-                toPurge.clear();
-                LOGGER.info("Hibernate query failed, aborting this indexer run", hibernateQueryError);
-                register(Step.PREPARE, Event.HIBERNATE_QUERY_ERROR);
-            } else {
-                register(Step.NOTE);
-            }
+            register(Step.NOTE);
         } catch (Throwable t) {
             LOGGER.error("failed to continue indexer", t);
         }


### PR DESCRIPTION
When originally trying to get the new indexer working for release I very probably overengineered its exception handling mostly through covering for confusion over nested exceptions. This PR simplifies the code by removing handling that is probably useless.