### PR TITLE
allow "Fake" to be added to DB format table of image readers

### DIFF
--- a/src/main/java/ome/services/util/DBEnumCheck.java
+++ b/src/main/java/ome/services/util/DBEnumCheck.java
@@ -46,9 +46,6 @@ public class DBEnumCheck extends BaseDBCheck {
             String name = formatReader.getClass().getSimpleName();
             if (name.endsWith("Reader")) {
                 name = name.substring(0, name.length() - 6);
-                if ("Fake".equals(name)) {
-                    continue;
-                }
                 formatNames.add(name);
                 if (formatReader.hasCompanionFiles()) {
                     formatNames.add("Companion/" + name);


### PR DESCRIPTION
Fixes https://github.com/ome/omero-server/issues/74.

If not starting from a fresh database then for this PR to take effect do,
```
omero admin stop
psql -c "DELETE FROM configuration WHERE name = 'DB check DBEnumCheck'"
omero admin start
```
Try importing a fake image file like `image.fake` and ensure that `Blitz-0.log` no longer warns like,
```
WARN  [    ome.formats.enums.IQueryEnumProvider] (1-thread-1) Enumeration 'Fake' does not exist in 'class omero.model.Format' returning 'null'
```