### PR TITLE
Only flush if we are in read-write mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     testImplementation("org.testng:testng:6.14.2")
     testImplementation("jmock:jmock:1.+")
     testImplementation("org.apache.directory.server:apacheds-all:1.5.7")
-    testImplementation('org.openmicroscopy:omero-common-test:5.5.3')
+    testImplementation('org.openmicroscopy:omero-common-test:5.5.4')
     testImplementation('org.slf4j:slf4j-log4j12:1.5.0')
     configurations.testCompile.exclude(group: 'org.slf4j', module: 'jcl-over-slf4j')
 
@@ -37,7 +37,7 @@ dependencies {
     // testCompile group: 'org.apache.directory.shared', name: 'shared-ldap-constants', version: '1.0.0-M1'
     // testCompile group: 'org.apache.directory.shared', name: 'shared-ldap', version: '0.9.15'
 
-    api('org.openmicroscopy:omero-renderer:5.5.3')
+    api('org.openmicroscopy:omero-renderer:5.5.4')
 
     // Spring framework stuff
     implementation("org.springframework:spring-context-support:4.3.14.RELEASE")

--- a/src/main/java/ome/services/RawFileBean.java
+++ b/src/main/java/ome/services/RawFileBean.java
@@ -223,7 +223,9 @@ public class RawFileBean extends AbstractStatefulBean implements RawFileStore {
             final String path = buffer.getPath();
 
             try {
-                buffer.flush(true);
+                if (!buffer.getMode().equals("r")) {
+                    buffer.flush(true);
+                }
             } catch (IOException ie) {
                 final String msg = "cannot flush " + path + ": " + ie;
                 log.warn(msg);

--- a/src/main/java/ome/services/RawFileBean.java
+++ b/src/main/java/ome/services/RawFileBean.java
@@ -228,7 +228,7 @@ public class RawFileBean extends AbstractStatefulBean implements RawFileStore {
                 }
             } catch (IOException ie) {
                 final String msg = "cannot flush " + path + ": " + ie;
-                log.warn(msg);
+                log.warn(msg, ie);
                 clean();
                 throw new ResourceError(msg);
             } finally {


### PR DESCRIPTION
In certain conditions on certain filesystems flushing, even if there is
nothing to flush and the file has been opened read-only, will result in
an IOException.  Sometimes this will be very low level and other times
just "permission denied".  There is no real reason to flush unless we
are read-write so only do this when we are in that mode.

We have noticed these types errors with repositories on NFSv4 with
creative ACL usage as well as on CIFS.

Also, log the exception if an error occurs in this block.

Requires ome/omero-romio#16.