### PR TITLE
Expand user session creation abilities

### DIFF
--- a/src/main/java/ome/services/sessions/SessionBean.java
+++ b/src/main/java/ome/services/sessions/SessionBean.java
@@ -90,7 +90,8 @@ public class SessionBean implements LocalSession {
             currentSession = null;
         }
 
-        final String agent = cd.getContext().get("omero.agent");
+        final String agent =
+            cd.size() > 0 ? cd.getContext().get("omero.agent") : null;
         try {
             final Principal principal = principal(defaultGroup, user);
             Future<Session> future = ex.submit(new Callable<Session>(){
@@ -149,7 +150,8 @@ public class SessionBean implements LocalSession {
             groupsLed = context.getLeaderOfGroupsList();
         }
 
-        final String agent = cd.getContext().get("omero.agent");
+        final String agent =
+            cd.size() > 0 ? cd.getContext().get("omero.agent") : null;
         try {
             Future<Session> future = ex.submit(new Callable<Session>(){
                 public Session call() throws Exception {

--- a/src/main/java/ome/services/sessions/SessionBean.java
+++ b/src/main/java/ome/services/sessions/SessionBean.java
@@ -90,13 +90,14 @@ public class SessionBean implements LocalSession {
             currentSession = null;
         }
 
+        final String agent = cd.getContext().get("omero.agent");
         try {
             final Principal principal = principal(defaultGroup, user);
             Future<Session> future = ex.submit(new Callable<Session>(){
                 public Session call() throws Exception {
                     final CreationRequest req = new CreationRequest();
                     req.principal = principal;
-                    req.agent = "createSession";
+                    req.agent = agent == null ? "createSession" : agent;
                     if (currentSession != null) {
                         final Experimenter sudoer = currentSession.getSudoer();
                         if (sudoer != null) {
@@ -112,7 +113,6 @@ public class SessionBean implements LocalSession {
         } catch (Exception e) {
             throw creationExceptionHandler(e);
         }
-
     }
 
     @RolesAllowed("user" /* group owner */)
@@ -149,12 +149,13 @@ public class SessionBean implements LocalSession {
             groupsLed = context.getLeaderOfGroupsList();
         }
 
+        final String agent = cd.getContext().get("omero.agent");
         try {
             Future<Session> future = ex.submit(new Callable<Session>(){
                 public Session call() throws Exception {
                     SessionManager.CreationRequest req = new SessionManager.CreationRequest();
                     req.principal = principal;
-                    req.agent = "OMERO.sudo";
+                    req.agent = agent == null ? "OMERO.sudo" : agent;
                     req.groupsLed = groupsLed;
                     req.timeToIdle = timeToIdleMilliseconds;
                     req.timeToLive = timeToLiveMilliseconds;
@@ -177,10 +178,13 @@ public class SessionBean implements LocalSession {
     @RolesAllowed( { "user", "guest" })
     public Session createSession(@NotNull Principal principal,
             @Hidden String credentials) {
-
         Session session = null;
         try {
-            session = mgr.createWithAgent(principal, credentials, "createSession", null);
+            String agent = cd.getContext().get("omero.agent");
+            if (agent == null) {
+                agent = "createSession";
+            }
+            session = mgr.createWithAgent(principal, credentials, agent, null);
         } catch (Exception e) {
             throw creationExceptionHandler(e);
         }

--- a/src/main/java/ome/services/sessions/SessionBean.java
+++ b/src/main/java/ome/services/sessions/SessionBean.java
@@ -180,7 +180,10 @@ public class SessionBean implements LocalSession {
             @Hidden String credentials) {
         Session session = null;
         try {
-            String agent = cd.getContext().get("omero.agent");
+            String agent = null;
+            if (cd.size() > 0) {
+                agent = cd.getContext().get("omero.agent");
+            }
             if (agent == null) {
                 agent = "createSession";
             }

--- a/src/main/java/ome/services/sessions/SessionManagerImpl.java
+++ b/src/main/java/ome/services/sessions/SessionManagerImpl.java
@@ -168,17 +168,18 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
 
     public void setDefaultTimeToIdle(long defaultTimeToIdle) {
         this.defaultTimeToIdle = defaultTimeToIdle;
-        this.maxUserTimeToIdle = Math.min(Long.MAX_VALUE / 10,
-                defaultTimeToIdle);
-        this.maxUserTimeToIdle *= 10;
+    }
+
+    public void setMaxUserTimeToIdle(long maxUserTimeToIdle) {
+        this.maxUserTimeToIdle = maxUserTimeToIdle;
     }
 
     public void setDefaultTimeToLive(long defaultTimeToLive) {
         this.defaultTimeToLive = defaultTimeToLive;
-        this.maxUserTimeToLive = Math.min(Long.MAX_VALUE / 10,
-                defaultTimeToLive);
-        this.maxUserTimeToLive *= 10;
+    }
 
+    public void setMaxUserTimeToLive(long maxUserTimeToLive) {
+        this.maxUserTimeToLive = maxUserTimeToLive ;
     }
 
     public void setPrincipalHolder(PrincipalHolder principal) {

--- a/src/main/java/ome/services/sessions/SessionManagerImpl.java
+++ b/src/main/java/ome/services/sessions/SessionManagerImpl.java
@@ -1020,21 +1020,18 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
             Session session, boolean trusted) {
 
         if (timeToLive != null) {
-
             if (trusted) {
                 session.setTimeToLive(timeToLive);
             } else {
-
-                // Let users set a value within reasons
-                long activeTTL = Math.min(maxUserTimeToLive, timeToLive);
-
-                // But if the value is 0, then the default must also be 0
-                if (activeTTL == 0 && defaultTimeToLive != 0) {
-                    throw new SecurityViolation("Cannot disable timeToLive. "
-                            + "Value must be between 1 and "
+                // Let users set a value within limit but if the value is 0,
+                // then the maximum must also be 0
+                if (maxUserTimeToLive != 0
+                    && (timeToLive > maxUserTimeToLive || timeToLive == 0)) {
+                    throw new SecurityViolation(
+                            "Cannot modify timeToLive beyond maximum: "
                             + maxUserTimeToLive);
                 }
-                session.setTimeToLive(activeTTL);
+                session.setTimeToLive(timeToLive);
             }
         }
 
@@ -1043,13 +1040,15 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
             if (trusted) {
                 session.setTimeToIdle(timeToIdle);
             } else {
-                long activeTTI = Math.min(maxUserTimeToIdle, timeToIdle);
-                if (activeTTI == 0 && defaultTimeToIdle != 0) {
-                    throw new SecurityViolation("Cannot disable timeToIdle. "
-                            + "Value must be between 1 and "
+                // Let users set a value within limit but if the value is 0,
+                // then the maximum must also be 0
+                if (maxUserTimeToLive != 0
+                    && (timeToIdle > maxUserTimeToIdle || timeToIdle == 0)) {
+                    throw new SecurityViolation(
+                            "Cannot modify timeToIdle beyond maximum: "
                             + maxUserTimeToIdle);
                 }
-                session.setTimeToIdle(activeTTI);
+                session.setTimeToIdle(timeToIdle);
             }
         }
     }

--- a/src/main/resources/ome/services/sec-primitives.xml
+++ b/src/main/resources/ome/services/sec-primitives.xml
@@ -154,6 +154,8 @@
     <property name="executor"        ref="executor"/>
     <property name="defaultTimeToIdle" value="${omero.sessions.timeout}"/>
     <property name="defaultTimeToLive" value="${omero.sessions.maximum}"/>
+    <property name="maxUserTimeToIdle" value="${omero.sessions.max_user_time_to_idle}"/>
+    <property name="maxUserTimeToLive" value="${omero.sessions.max_user_time_to_live}"/>
     <property name="counterFactory"  ref="sessionCounterFactory"/>
     <property name="readOnly"        ref="readOnlyStatus"/>
     <property name="sessionProvider" ref="sessionProvider"/>

--- a/src/main/resources/omero-server.properties
+++ b/src/main/resources/omero-server.properties
@@ -270,12 +270,20 @@ omero.search.ram_buffer_size=64
 ## straightforward
 #############################################
 
-# Sets the duration of inactivity in milliseconds after which
-# a login is required.
+# Sets the default duration of inactivity in milliseconds after
+# which a login is required.
 omero.sessions.timeout=600000
+# Sets the default duration before a login is required; 0
+# signifies never.
 omero.sessions.maximum=0
 omero.sessions.sync_interval=120000
 omero.sessions.sync_force=1800000
+# Sets the maximum duration a user can request before a login
+# is required due to inactivity.
+omero.sessions.max_user_time_to_idle=6000000
+# Sets the maximum duration a user can request before a login
+# is required (0 signifies never).
+omero.sessions.max_user_time_to_live=0
 
 #############################################
 ## threading configuring

--- a/src/test/java/ome/server/utests/sessions/SessMgrUnitTest.java
+++ b/src/test/java/ome/server/utests/sessions/SessMgrUnitTest.java
@@ -102,6 +102,9 @@ public class SessMgrUnitTest extends MockObjectTestCase {
     // State
     final Long TTL = 300 * 1000L;
     final Long TTI = 100 * 1000L;
+    final Long maxUserTTL = TTL;
+    final Long maxUserTTI = TTI;
+
     Session session = new Session();
     Principal principal = new Principal("u", "g", "Test");
     String credentials = "password";
@@ -145,6 +148,8 @@ public class SessMgrUnitTest extends MockObjectTestCase {
         mgr.setApplicationContext(ctx);
         mgr.setDefaultTimeToIdle(TTI);
         mgr.setDefaultTimeToLive(TTL);
+        mgr.setMaxUserTimeToIdle(maxUserTTI);
+        mgr.setMaxUserTimeToLive(maxUserTTL);
         mgr.setSessionProvider(new SessionProviderInDb(roles, nodeProvider, executor));
 
         session = mgr.doDefine();
@@ -514,7 +519,7 @@ public class SessMgrUnitTest extends MockObjectTestCase {
 
     }
 
-    @Test
+    @Test(expectedExceptions = SecurityViolation.class)
     public void testTimeoutUpdatesTooBig() throws Exception {
 
         testTimeoutDefaults();
@@ -525,9 +530,6 @@ public class SessMgrUnitTest extends MockObjectTestCase {
         s.setTimeToLive(Long.MAX_VALUE);
         s.setTimeToIdle(Long.MAX_VALUE);
         s = mgr.update(s);
-
-        assertEquals(3000000, s.getTimeToLive().longValue());
-        assertEquals(1000000, s.getTimeToIdle().longValue());
 
     }
 


### PR DESCRIPTION
A system wide, configurable maximum time to idle and time to live is now
in place.  Regular users are allowed to create new sessions with
timeouts up to these limits.  The previous limits were 10x the default
time to idle and time to live and those are now the default configured
values.  These new properties are:

 * `omero.sessions.max_user_time_to_idle`
 * `omero.sessions.max_user_time_to_live`

Furthermore, it is now possible to pass an "omero.agent" as part of call
context to set the user agent on sessions created using the session
service.  For example:

    createUserSession(0, 600000, 'test', {'omero.agent': 'my agent'})