### PR TITLE
Have even read-only servers leave session loaded.

### DIFF
--- a/src/main/java/ome/security/basic/BasicSecuritySystem.java
+++ b/src/main/java/ome/security/basic/BasicSecuritySystem.java
@@ -552,12 +552,7 @@ public class BasicSecuritySystem implements SecuritySystem,
 
         }
 
-        final ome.model.meta.Session session;
-        if (isReadOnly) {
-            session = new ome.model.meta.Session(sessionId, false);
-        } else {
-            session = sessionProvider.findSessionById(sessionId, sf);
-        }
+        final ome.model.meta.Session session = sessionProvider.findSessionById(sessionId, sf);
 
         tokenHolder.setToken(callGroup.getGraphHolder());
 

--- a/src/main/java/ome/security/basic/BasicSecuritySystem.java
+++ b/src/main/java/ome/security/basic/BasicSecuritySystem.java
@@ -552,7 +552,12 @@ public class BasicSecuritySystem implements SecuritySystem,
 
         }
 
-        final ome.model.meta.Session session = sessionProvider.findSessionById(sessionId, sf);
+        final ome.model.meta.Session session;
+        if (isReadOnly) {
+            session = new ome.model.meta.Session(sessionId, false);
+        } else {
+            session = sessionProvider.findSessionById(sessionId, sf);
+        }
 
         tokenHolder.setToken(callGroup.getGraphHolder());
 

--- a/src/main/java/ome/security/basic/BasicSecuritySystem.java
+++ b/src/main/java/ome/security/basic/BasicSecuritySystem.java
@@ -37,6 +37,7 @@ import ome.model.meta.EventLog;
 import ome.model.meta.Experimenter;
 import ome.model.meta.ExperimenterGroup;
 import ome.model.meta.GroupExperimenterMap;
+import ome.model.meta.Share;
 import ome.parameters.Parameters;
 import ome.security.ACLVoter;
 import ome.security.AdminAction;
@@ -448,6 +449,7 @@ public class BasicSecuritySystem implements SecuritySystem,
         }
 
         // Ensure that sudoer has name loaded for SimpleEventContext.copy
+        final boolean isShare;
         if (ec instanceof SessionContext) {
             final ome.model.meta.Session session = ((SessionContext) ec).getSession();
             Experimenter sudoer = session.getSudoer();
@@ -462,6 +464,9 @@ public class BasicSecuritySystem implements SecuritySystem,
                 sudoer.setOmeName(sudoerName);
                 session.setSudoer(sudoer);
             }
+            isShare = session instanceof Share;
+        } else {
+            isShare = false;
         }
 
         // Refill current details
@@ -553,7 +558,8 @@ public class BasicSecuritySystem implements SecuritySystem,
         }
 
         final ome.model.meta.Session session;
-        if (isReadOnly) {
+        if (isShare) {
+            /* Cannot read annotations on session. */
             session = new ome.model.meta.Session(sessionId, false);
         } else {
             session = sessionProvider.findSessionById(sessionId, sf);

--- a/src/test/java/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
+++ b/src/test/java/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
@@ -257,13 +257,14 @@ public abstract class AbstractBasicSecuritySystemTest extends
                 returnValue(group));
         sf.mockQuery.expects(atMostOnce()).method("execute").will(
                 returnValue(true));
+        sf.mockQuery.expects(atMostOnce()).method("findByQuery").will(
+                returnValue(event.getSession()));
+        sf.mockQuery.expects(atMostOnce()).method("find").will(
+                returnValue(event.getSession()));
+        sf.mockAdmin.expects(atMostOnce()).method("userProxy").will(
+                returnValue(user));
+
         if (!readOnly) {
-            sf.mockQuery.expects(atMostOnce()).method("findByQuery").will(
-                    returnValue(event.getSession()));
-            sf.mockQuery.expects(atMostOnce()).method("find").will(
-                    returnValue(event.getSession()));
-            sf.mockAdmin.expects(atMostOnce()).method("userProxy").will(
-                    returnValue(user));
             sf.mockUpdate.expects(once()).method("saveAndReturnObject").will(
                     returnValue(event));
         }


### PR DESCRIPTION
Fix https://github.com/ome/omero-server/issues/76 by having even read-only servers maintain a loaded session. Smoketest on an actual [read-only server](https://docs.openmicroscopy.org/omero/5.6/developers/Server/Clustering.html#read-only) before approving.