### PR TITLE
More cleanly adapt basic security system for read-only mode.

### DIFF
--- a/src/main/java/ome/security/basic/BasicSecuritySystem.java
+++ b/src/main/java/ome/security/basic/BasicSecuritySystem.java
@@ -9,7 +9,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -22,8 +21,6 @@ import ome.conditions.InternalException;
 import ome.conditions.SecurityViolation;
 import ome.conditions.SessionTimeoutException;
 import ome.model.IObject;
-import ome.model.annotations.Annotation;
-import ome.model.annotations.CommentAnnotation;
 import ome.model.enums.AdminPrivilege;
 import ome.model.enums.EventType;
 import ome.model.internal.Details;
@@ -355,12 +352,12 @@ public class BasicSecuritySystem implements SecuritySystem,
     }
 
     /**
-     * Check the given group context using the database.
+     * Check the given group context.
      * @param sessionId a session ID
      * @param groupId a group ID
      * @return if the group context is permitted for the given session
      */
-    private boolean isGroupContextPermittedReadWrite(long sessionId, long groupId) {
+    protected boolean isGroupContextPermitted(long sessionId, long groupId) {
         final LocalQuery query = (LocalQuery) sf.getQueryService();
         return query.execute(new HibernateCallback<Boolean>() {
             public Boolean doInHibernate(Session session) {
@@ -382,32 +379,11 @@ public class BasicSecuritySystem implements SecuritySystem,
     }
 
     /**
-     * Check the given group context using the session provider.
-     * @param sessionId a session ID
-     * @param groupId a group ID
-     * @return if the group context is permitted for the given session
-     */
-    private boolean isGroupContextPermittedReadOnly(long sessionId, long groupId) {
-        final ome.model.meta.Session session = sessionProvider.findSessionById(sessionId, sf);
-        final Iterator<Annotation> sessionAnnotations = session.linkedAnnotationIterator();
-        while (sessionAnnotations.hasNext()) {
-            final Annotation sessionAnnotation = sessionAnnotations.next();
-            if (sessionAnnotation instanceof CommentAnnotation &&
-                    SessionManagerImpl.GROUP_SUDO_NS.equals(sessionAnnotation.getNs()) &&
-                    roles.isRootUser(sessionAnnotation.getDetails().getOwner()) &&
-                    !isGroupContextPermitted(groupId, ((CommentAnnotation) sessionAnnotation).getTextValue())) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
      * @param groupId a group ID
      * @param permittedGroupIds a comma-separated string of group IDs
      * @return if the string of IDs contains the given group
      */
-    private boolean isGroupContextPermitted(long groupId, String permittedGroupIds) {
+    protected boolean isGroupContextPermitted(long groupId, String permittedGroupIds) {
         final String requiredGroupId = Long.toString(groupId);
         for (final String permittedGroupId : Splitter.on(',').split(permittedGroupIds)) {
             if (requiredGroupId.equals(permittedGroupId)) {
@@ -471,9 +447,7 @@ public class BasicSecuritySystem implements SecuritySystem,
         final long sessionId = ec.getCurrentSessionId();
 
         // Check that group context is consistent with any group sudo.
-        if (sessionProvider instanceof SessionProviderInMemory ?
-                !isGroupContextPermittedReadOnly(sessionId, groupId) :
-                !isGroupContextPermittedReadWrite(sessionId, groupId)) {
+        if (!isGroupContextPermitted(sessionId, groupId)) {
             throw new SecurityViolation("Group-sudo session cannot change context!");
         }
 

--- a/src/main/java/ome/security/basic/BasicSecuritySystemReadOnly.java
+++ b/src/main/java/ome/security/basic/BasicSecuritySystemReadOnly.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.security.basic;
+
+import java.util.Iterator;
+import java.util.List;
+
+import ome.model.annotations.Annotation;
+import ome.model.annotations.CommentAnnotation;
+import ome.security.ACLVoter;
+import ome.security.EventProvider;
+import ome.security.SecurityFilter;
+import ome.security.SystemTypes;
+import ome.security.policy.PolicyService;
+import ome.services.sessions.SessionManager;
+import ome.services.sessions.SessionManagerImpl;
+import ome.services.sessions.SessionProvider;
+import ome.system.Roles;
+import ome.system.ServiceFactory;
+
+/**
+ * Provides a group context check that does not rely on SQL to bypass interception by Hibernate.
+ * This read-only variant of the service queries group sudo annotations from the session provider instead of the database.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.5.7
+ */
+public class BasicSecuritySystemReadOnly extends BasicSecuritySystem {
+
+    public BasicSecuritySystemReadOnly(OmeroInterceptor interceptor, SystemTypes sysTypes, CurrentDetails cd,
+            SessionManager sessionManager, SessionProvider sessionProvider, EventProvider eventProvider, Roles roles,
+            ServiceFactory sf, TokenHolder tokenHolder, List<SecurityFilter> filters, PolicyService policyService,
+            ACLVoter aclVoter) {
+        super(interceptor, sysTypes, cd, sessionManager, sessionProvider, eventProvider, roles, sf, tokenHolder, filters,
+                policyService, aclVoter);
+    }
+
+    @Override
+    protected boolean isGroupContextPermitted(long sessionId, long groupId) {
+        final ome.model.meta.Session session = sessionProvider.findSessionById(sessionId, sf);
+        final Iterator<Annotation> sessionAnnotations = session.linkedAnnotationIterator();
+        while (sessionAnnotations.hasNext()) {
+            final Annotation sessionAnnotation = sessionAnnotations.next();
+            if (sessionAnnotation instanceof CommentAnnotation &&
+                    SessionManagerImpl.GROUP_SUDO_NS.equals(sessionAnnotation.getNs()) &&
+                    roles.isRootUser(sessionAnnotation.getDetails().getOwner()) &&
+                    !isGroupContextPermitted(groupId, ((CommentAnnotation) sessionAnnotation).getTextValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/resources/ome/services/indexer.xml
+++ b/src/main/resources/ome/services/indexer.xml
@@ -126,6 +126,13 @@
     <constructor-arg><null/></constructor-arg>
   </bean>
 
+  <bean id="basicSecuritySystemSubstituter" class="ome.services.util.BeanInstantiationSubstituter">
+    <constructor-arg ref="readOnlyStatus"/>
+    <constructor-arg value="basicSecuritySystem"/>
+    <constructor-arg value="ome.security.basic.BasicSecuritySystemReadOnly"/>
+    <property name="isWriteDb" value="true"/>  <!-- see SessionProviderInDb.isReadOnly -->
+  </bean>
+
   <bean id="eventHandler" class="ome.security.basic.NullEventHandler">
     <description>
     Scope: private

--- a/src/main/resources/ome/services/pixeldata.xml
+++ b/src/main/resources/ome/services/pixeldata.xml
@@ -103,6 +103,13 @@
     <constructor-arg><null/></constructor-arg>
   </bean>
 
+  <bean id="basicSecuritySystemSubstituter" class="ome.services.util.BeanInstantiationSubstituter">
+    <constructor-arg ref="readOnlyStatus"/>
+    <constructor-arg value="basicSecuritySystem"/>
+    <constructor-arg value="ome.security.basic.BasicSecuritySystemReadOnly"/>
+    <property name="isWriteDb" value="true"/>  <!-- see SessionProviderInDb.isReadOnly -->
+  </bean>
+
   <bean id="eventHandler" class="ome.security.basic.NullEventHandler">
     <description>
     Scope: private

--- a/src/main/resources/ome/services/sec-system.xml
+++ b/src/main/resources/ome/services/sec-system.xml
@@ -55,6 +55,13 @@
     <constructor-arg ref="aclVoter"/>
   </bean>
 
+  <bean id="basicSecuritySystemSubstituter" class="ome.services.util.BeanInstantiationSubstituter">
+    <constructor-arg ref="readOnlyStatus"/>
+    <constructor-arg value="basicSecuritySystem"/>
+    <constructor-arg value="ome.security.basic.BasicSecuritySystemReadOnly"/>
+    <property name="isWriteDb" value="true"/>  <!-- see SessionProviderInDb.isReadOnly -->
+  </bean>
+
   <bean id="securityWiring" class="ome.security.basic.BasicSecurityWiring"
    lazy-init="true">
     <property name="principalHolder" ref="principalHolder"/>


### PR DESCRIPTION
This PR refactors code from the 2019-SV6 fix to remove a brittle `sessionProvider instanceof SessionProviderInMemory` conditional by replacing it with the Spring-based approach used by the other read-only server code. With a read-write server `Test_2019_SV6_Data` and `Test_2019_SV6_Users` should continue to pass. A read-only server should continue to be usable and its logs should note,
> in read-only state so setting Spring bean named basicSecuritySystem to instantiate ome.security.basic.BasicSecuritySystemReadOnly