### PR TITLE
Add note about binary access restrictions on groups.

### DIFF
--- a/src/main/resources/omero-server.properties
+++ b/src/main/resources/omero-server.properties
@@ -59,8 +59,8 @@ omero.policy.bean=defaultPolicyService
 #
 # Configuration properties of the same name can be applied
 # to individual groups as well. E.g. adding,
-# omero.policy.binary_access=-read to a group's ``config`` property, you can
-# prevent group-members from downloading original files.
+# omero.policy.binary_access=-read to a group's ``config`` property,
+# you can prevent group-members from downloading original files.
 #
 # Configuration is pessimistic: if there is a negative
 # *either* on the group *or* at the server-level, the

--- a/src/main/resources/omero-server.properties
+++ b/src/main/resources/omero-server.properties
@@ -60,7 +60,8 @@ omero.policy.bean=defaultPolicyService
 # Configuration properties of the same name can be applied
 # to individual groups as well. E.g. adding,
 # omero.policy.binary_access=-read to a group's ``config`` property,
-# you can prevent group-members from downloading original files.
+# you can prevent group-members from downloading original files, as at
+# https://docs.openmicroscopy.org/latest/omero/sysadmins/customization.html#download-restrictions
 #
 # Configuration is pessimistic: if there is a negative
 # *either* on the group *or* at the server-level, the

--- a/src/main/resources/omero-server.properties
+++ b/src/main/resources/omero-server.properties
@@ -59,7 +59,7 @@ omero.policy.bean=defaultPolicyService
 #
 # Configuration properties of the same name can be applied
 # to individual groups as well. E.g. adding,
-# omero.policy.binary_access=-read to a group, you can
+# omero.policy.binary_access=-read to a group's ``config`` property, you can
 # prevent group-members from downloading original files.
 #
 # Configuration is pessimistic: if there is a negative


### PR DESCRIPTION
Adds a useful hint to the properties documentation in support of https://github.com/ome/ome-documentation/pull/2127.