### PR TITLE
Fail early if we are in read-only mode

### DIFF
--- a/src/main/java/ome/security/auth/LdapPasswordProvider.java
+++ b/src/main/java/ome/security/auth/LdapPasswordProvider.java
@@ -149,6 +149,10 @@ public class LdapPasswordProvider extends ConfigurablePasswordProvider {
                 // Perhaps a hard-coded value in "password"."dn"
                 throw new ValidationException(msg);
             } else {
+                if (readOnly == true) {
+                    throw new IllegalStateException(
+                            "Cannot synchronize user!");
+                }
                 ldapUtil.synchronizeLdapUser(user);
                 return loginAttempt(user,
                         ldapUtil.validatePassword(dn1, password));


### PR DESCRIPTION
Allowing `synchronizeLdapUser()` to be called in a read-only transaction
may result in very obtuse low level transactional exceptions being
thrown.  This will depend heavily on the exact nature of the
synchronization required.  Thus, it is safest to fail early as the
implementation of this method already does if the user does not exist.
This is the consistent with the runtime expectations of
`SessionManagerImpl.executeCheckPassword()`.