### PR TITLE
set time units

### DIFF
--- a/src/main/resources/omero-server.properties
+++ b/src/main/resources/omero-server.properties
@@ -279,10 +279,10 @@ omero.sessions.timeout=600000
 omero.sessions.maximum=0
 omero.sessions.sync_interval=120000
 omero.sessions.sync_force=1800000
-# Sets the maximum duration a user can request before a login
+# Sets the maximum duration in milliseconds a user can request before a login
 # is required due to inactivity.
 omero.sessions.max_user_time_to_idle=6000000
-# Sets the maximum duration a user can request before a login
+# Sets the maximum duration in milliseconds a user can request before a login
 # is required (0 signifies never).
 omero.sessions.max_user_time_to_live=0
 


### PR DESCRIPTION
missing unit mentioned on https://github.com/ome/ome-documentation/pull/2142
cc @will-moore 