### PR TITLE
new JDBC connection configuration

### DIFF
--- a/src/main/resources/ome/services/datalayer.xml
+++ b/src/main/resources/ome/services/datalayer.xml
@@ -147,7 +147,7 @@
     <property name="properties">
       <props>
         <prop key="driverClassName">${omero.db.driver}</prop>
-        <prop key="url">jdbc:postgresql://${omero.db.host}:${omero.db.port}/${omero.db.name}</prop>
+        <prop key="url">${omero.db.url}</prop>
         <prop key="user">${omero.db.user}</prop>
         <prop key="password">${omero.db.pass}</prop>
       </props>


### PR DESCRIPTION
Fixes #107 by providing properties,
```
omero.db.properties=tcpKeepAlive=true
omero.db.url=jdbc:postgresql://${omero.db.host}:${omero.db.port}/${omero.db.name}?${omero.db.properties}
```