### PR TITLE
Allow sending of e-mail with TLS.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,13 +62,15 @@ dependencies {
 
     implementation("commons-beanutils:commons-beanutils:1.9.3")
 
-    implementation("com.sun.mail:javax.mail:1.6.1")
+    implementation("com.sun.mail:javax.mail:1.6.2")
 
     implementation("com.mortennobel:java-image-scaling:0.8.6")
 
     implementation("org.quartz-scheduler:quartz:2.2.1")
 
-    implementation("org.subethamail:subethasmtp:3.1.7")
+    implementation("org.subethamail:subethasmtp:3.1.7") {
+        exclude group: 'javax.mail'
+    }
 
     implementation("net.sf.ehcache:ehcache:2.10.4")
 }

--- a/src/main/java/ome/services/mail/MailUtil.java
+++ b/src/main/java/ome/services/mail/MailUtil.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2014 University of Dundee. All rights reserved.
+ *   Copyright 2014-2020 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -44,6 +44,7 @@ public class MailUtil {
         }
         this.sender = sender;
         this.mailSender = mailSender;
+        log.info("JavaMail version is {}", InternetAddress.class.getPackage().getImplementationVersion());
     }
 
     /**

--- a/src/main/resources/ome/services/services.xml
+++ b/src/main/resources/ome/services/services.xml
@@ -2,7 +2,7 @@
 <!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# Copyright 2006-2018 University of Dundee. All rights reserved.
+# Copyright 2006-2020 University of Dundee. All rights reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -270,18 +270,10 @@
       class="org.springframework.mail.javamail.JavaMailSenderImpl">
       <property name="host" value="${omero.mail.host}" />
       <property name="port" value="${omero.mail.port}" />
+      <property name="username" value="${omero.mail.username}" />
+      <property name="password" value="${omero.mail.password}" />
       <property name="protocol" value="${omero.mail.transport.protocol}" />
-      <property name="session" ref="mailSession" />
       <property name="javaMailProperties">
-          <props>
-              <prop key="mail.smtp.sendpartial">true</prop>
-          </props>
-      </property>
-  </bean>
-
-  <!-- setup an authenticated session -->
-  <bean id="mailSession" class="javax.mail.Session" factory-method="getInstance">
-      <constructor-arg>
           <props>
               <prop key="mail.smtp.auth">${omero.mail.smtp.auth}</prop>
               <prop key="mail.smtp.debug">${omero.mail.smtp.debug}</prop>
@@ -293,14 +285,7 @@
               <prop key="mail.smtp.socketFactory.fallback">${omero.mail.smtp.socketFactory.fallback}</prop>
               <prop key="mail.smtp.timeout">${omero.mail.smtp.timeout}</prop>
           </props>
-      </constructor-arg>
-      <constructor-arg ref="smtpAuthenticator" />
-  </bean>
-
-  <!-- Authenticator implementation -->
-  <bean id="smtpAuthenticator" class="ome.security.SmtpAuthenticator">
-      <constructor-arg value="${omero.mail.username}" />
-      <constructor-arg value="${omero.mail.password}" />
+      </property>
   </bean>
 
   <!-- this is a template message that we can pre-load with default state -->


### PR DESCRIPTION
Fixes #109. The following is akin to a working configuration:
```
omero.mail.config=true
omero.mail.from=whatever@gmail.com
omero.mail.host=smtp.googlemail.com
omero.mail.port=587
omero.mail.smtp.auth=true
omero.mail.username=whatever@gmail.com
omero.mail.password=mypassword
omero.mail.smtp.starttls.enable=true
```
Alternatively, changing the port number and the last line,
```
omero.mail.config=true
omero.mail.from=whatever@gmail.com
omero.mail.host=smtp.googlemail.com
omero.mail.port=465
omero.mail.smtp.auth=true
omero.mail.username=whatever@gmail.com
omero.mail.password=mypassword
omero.mail.smtp.socketFactory.class=javax.net.ssl.SSLSocketFactory
```
This needs your account to enable "Less secure app access". You can also try mail services other than Google's.