### PR TITLE
Prepare build for releasing OMERO 5.6.3.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "org.openmicroscopy"
-version = "5.6.1-SNAPSHOT"
+version = "5.6.1"
 
 repositories {
     mavenLocal()
@@ -27,7 +27,7 @@ dependencies {
     testImplementation("org.testng:testng:6.14.2")
     testImplementation("jmock:jmock:1.+")
     testImplementation("org.apache.directory.server:apacheds-all:1.5.7")
-    testImplementation('org.openmicroscopy:omero-common-test:5.5.6')
+    testImplementation('org.openmicroscopy:omero-common-test:5.5.7')
     testImplementation('org.slf4j:slf4j-log4j12:1.5.0')
     configurations.testCompile.exclude(group: 'org.slf4j', module: 'jcl-over-slf4j')
 
@@ -36,7 +36,7 @@ dependencies {
     // testCompile group: 'org.apache.directory.shared', name: 'shared-ldap-constants', version: '1.0.0-M1'
     // testCompile group: 'org.apache.directory.shared', name: 'shared-ldap', version: '0.9.15'
 
-    api('org.openmicroscopy:omero-renderer:5.5.6')
+    api('org.openmicroscopy:omero-renderer:5.5.7')
 
     // Spring framework stuff
     implementation("org.springframework:spring-context-support:4.3.14.RELEASE")


### PR DESCRIPTION
Adjust build to correspond with latest release notes in #111.

--exclude for now