### PR TITLE
Handle Well Annotation references during import

### DIFF
--- a/src/main/java/ome/formats/OMEROMetadataStore.java
+++ b/src/main/java/ome/formats/OMEROMetadataStore.java
@@ -1733,6 +1733,17 @@ public class OMEROMetadataStore
      * @param target Target model object.
      * @param reference Reference model object.
      */
+    private void handleReference(Well target, Annotation reference)
+    {
+        target.linkAnnotation(reference);
+    }
+
+    /**
+     * Handles linking a specific reference object to a target object in our
+     * object graph.
+     * @param target Target model object.
+     * @param reference Reference model object.
+     */
     private void handleReference(FileAnnotation target, OriginalFile reference)
     {
         target.setFile(reference);

--- a/src/main/java/ome/formats/OMEROMetadataStore.java
+++ b/src/main/java/ome/formats/OMEROMetadataStore.java
@@ -619,6 +619,11 @@ public class OMEROMetadataStore
                                         (Reagent) referenceObject);
                         continue;
                     }
+                    if (referenceObject instanceof Annotation) {
+                            handleReference((Well) targetObject,
+                                            (Annotation) referenceObject);
+                            continue;
+                    }
                 }
                 else if (targetObject instanceof Reagent)
                 {


### PR DESCRIPTION
Found during the testing of https://github.com/ome/ome-model/pull/131

Well Annotation references are currently not handled by `OMEROMetadataStore`. This the import of a file that includes a `WellAnnotationRef` object should fail with an `ApiUsageException` exception of type

```
    serverExceptionClass = "ome.conditions.ApiUsageException"
    message = "Missing reference handler for Annotation:2(ome.model.annotations.TagAnnotation:Hash_671437134) --> Well:1.2.1(ome.model.screen.Well:Hash_1523927533) reference."
```

This PR fixes `updateReferences` to handle this scenario. To test this PR, use the sample file provided in https://github.com/ome/ome-model/pull/131#pullrequestreview-688894378, import it into a server (requires the ome-model PR) and check the import is successful and that two wells are annotated with tags as expected.

Given that no Bio-Formats reader is currently implementing `setWellAnnotationRef`, the main driver/application for this fix is probably OME-TIFF. It probably makes sense to wait until a version of Bio-Formats including the `ome-model` fix is merged into `omero-model` to get this merged and released.