### PR TITLE
Upgrade commons-io from 1.x to 2.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,8 @@ dependencies {
     }
 
     implementation("net.sf.ehcache:ehcache:2.10.4")
+
+    implementation("commons-io:commons-io:2.6")
 }
 
 

--- a/src/main/java/ome/services/scripts/ScriptRepoHelper.java
+++ b/src/main/java/ome/services/scripts/ScriptRepoHelper.java
@@ -6,7 +6,6 @@
 package ome.services.scripts;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -77,7 +76,7 @@ public class ScriptRepoHelper extends OnContextRefreshedEventListener {
      * matching scripts in the given directory.
      */
     public final static IOFileFilter BASE_SCRIPT_FILTER = new AndFileFilter(Arrays
-            .asList(new FileFilter[] { EmptyFileFilter.NOT_EMPTY,
+            .asList(new IOFileFilter[] { EmptyFileFilter.NOT_EMPTY,
                     HiddenFileFilter.VISIBLE, CanReadFileFilter.CAN_READ }));
 
     private final Map<String, ScriptFileType> types =
@@ -191,8 +190,8 @@ public class ScriptRepoHelper extends OnContextRefreshedEventListener {
                 event.getApplicationContext()
                     .getBeansOfType(ScriptFileType.class));
 
-        final List<FileFilter> andFilters = new ArrayList<FileFilter>();
-        final List<FileFilter> orFilters= new ArrayList<FileFilter>();
+        final List<IOFileFilter> andFilters = new ArrayList<IOFileFilter>();
+        final List<IOFileFilter> orFilters= new ArrayList<IOFileFilter>();
         for (Map.Entry<String, ScriptFileType> entry : types.entrySet()) {
             IOFileFilter found = entry.getValue().getFileFilter();
             log.info("Registering {}: {}", entry.getKey(), found);


### PR DESCRIPTION
Unlike the rest of the OMERO Java components which declare commons-io:commons-io:2.6 as a dependency in build.gradle, this component still inherits the 1.x version of commons-io transitively (via Bio-Formats and its jhdf5 dependency).
As we are trying to upgrade the underlying jhdf5 library, the ScriptRepoHelper class needs to be updated to be compatible with commons-io 2.x

See also https://github.com/ome/bioformats/pull/3745