### PR TITLE
Add the max_plane_float_override config variable to ConfiguredTileSizes

### DIFF
--- a/src/main/resources/ome/services/service-ome.io.nio.PixelsService.xml
+++ b/src/main/resources/ome/services/service-ome.io.nio.PixelsService.xml
@@ -52,6 +52,7 @@
     <constructor-arg index="1" value="${omero.pixeldata.tile_height}"/>
     <constructor-arg index="2" value="${omero.pixeldata.max_plane_width}"/>
     <constructor-arg index="3" value="${omero.pixeldata.max_plane_height}"/>
+    <constructor-arg index="4" value="${omero.pixeldata.max_plane_float_override}"/>
   </bean>
 
   <alias name="${omero.pixeldata.tile_sizes_bean}" alias="tileSizes"/>


### PR DESCRIPTION
See https://github.com/ome/omero-model/pull/81
And https://github.com/ome/omero-common/pull/35
Fixes ome/omero-romio#36
Add floating point override config value to `ConfiguredTileSizes` constructor
