### PR TITLE
Dependencies update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,6 @@ dependencies {
     testImplementation("jmock:jmock:1.+")
     testImplementation('org.openmicroscopy:omero-common-test:5.6.0')
 
-    // https://mvnrepository.com/artifact/org.apache.directory.shared/shared-ldap
-    // testCompile group: 'org.apache.directory.shared', name: 'shared-ldap-constants', version: '1.0.0-M1'
-    // testCompile group: 'org.apache.directory.shared', name: 'shared-ldap', version: '0.9.15'
-
     api('org.openmicroscopy:omero-renderer:5.5.11')
 
     // Spring framework stuff

--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,9 @@ ext {
 }
 
 dependencies {
-    testImplementation("org.testng:testng:7.5") {
-        //exclude to pass compilation step due to conflicting versions in the path
-        exclude group: "org.slf4j", module: "slf4j-log4j12"
-    }
+    testImplementation("org.testng:testng:7.5")
     testImplementation("jmock:jmock:1.+")
-    testImplementation("org.apache.directory.server:apacheds-all:1.5.7")
     testImplementation('org.openmicroscopy:omero-common-test:5.6.0')
-    testImplementation('org.slf4j:slf4j-log4j12:1.5.0')
 
     // https://mvnrepository.com/artifact/org.apache.directory.shared/shared-ldap
     // testCompile group: 'org.apache.directory.shared', name: 'shared-ldap-constants', version: '1.0.0-M1'

--- a/src/test/resources/test.xml
+++ b/src/test/resources/test.xml
@@ -12,9 +12,5 @@
   <dependencies defaultconfmapping="test->*">
     <dependency name="server" rev="${omero.version}" changing="true"/>
     <dependency name="common-test" rev="${omero.version}" changing="true"/>
-    <dependency name="blitz-test" rev="${omero.version}" changing="true"/>
-    <!-- Build dependencies for test -->
-    <dependency org="org.apache.directory.server" name="apacheds-all" rev="${versions.apacheds}"/>
-    <dependency org="org.apache.directory.shared" name="shared-ldap-constants" rev="${versions.shared-ldap}"/>
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
This PR removes dependencies not needed that were creating conflicts with the upgrade of testNG