### PR TITLE
Set class in doc

### DIFF
--- a/src/main/java/ome/api/local/LocalSession.java
+++ b/src/main/java/ome/api/local/LocalSession.java
@@ -16,7 +16,7 @@ public interface LocalSession extends ome.api.ISession {
     /**
      * Lookups a Session without updating the last access time.
      *
-     * Otherwise, behaves identically to {@link #getSession()}.
+     * Otherwise, behaves identically to {@link ome.services.sessions.SessionContext#getSession()}.
      */
     Session getSessionQuietly(String uuid);
 }


### PR DESCRIPTION
This should fix
```
> Task :omero-server:javadoc
/home/omero/workspace/OMERO-build-build/omero-server/src/main/java/ome/api/local/LocalSession.java:19: warning - Tag @link: reference not found: #getSession()
```