### PR TITLE
Fileset indexing: address performance issues and add configurability

### DIFF
--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -65,7 +65,7 @@ public class FullTextBridge extends BridgeHelper {
     final protected OriginalFilesService files;
     final protected Map<String, FileParser> parsers;
     final protected Class<FieldBridge>[] classes;
-    final protected int maxFilesetSize;
+    protected int maxFilesetSize;
 
     /**
      * Since this constructor provides the instance with no way of parsing
@@ -104,34 +104,18 @@ public class FullTextBridge extends BridgeHelper {
     @SuppressWarnings("unchecked")
     public FullTextBridge(OriginalFilesService files,
             Map<String, FileParser> parsers, Class<FieldBridge>[] bridgeClasses) {
-        this(files, parsers, bridgeClasses, 1);
-    }
-
-    /**
-     * Main constructor.
-     *
-     * @param files
-     *            {@link OriginalFilesService} for getting access to binary files.
-     * @param parsers
-     *            List of {@link FileParser} instances which are currently
-     *            configured.
-     * @param bridgeClasses
-     *            set of {@link FieldBridge bridge classes} which will be
-     *            instantiated via a no-arg constructor.
-     * @param maxFilesetSize
-     *            maximum size of the fileset to be considered for indexing
-     * @see <a
-     *      href="https://omero.readthedocs.io/en/stable/developers/Modules/Search/Bridges.html">Bridges</a>
-     */
-    @SuppressWarnings("unchecked")
-    public FullTextBridge(OriginalFilesService files,
-            Map<String, FileParser> parsers, Class<FieldBridge>[] bridgeClasses,
-            int maxFilesetSize) {
         this.files = files;
         this.parsers = parsers;
         this.classes = bridgeClasses == null ? new Class[] {} : bridgeClasses;
+    }
+
+    /**
+     * Sets the cut-off for indexing filesets
+     * @param maxFilesetSize the maximume fileset size
+     */
+    public void setMaxFilesetSize(int maxFilesetSize) {
+        logger().info("Setting maximum fileset size: {}", maxFilesetSize);
         this.maxFilesetSize = maxFilesetSize;
-        logger().info("Maximum fileset size: {}", maxFilesetSize);
     }
 
     /**

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -55,10 +55,8 @@ import java.util.Map;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 3.0-Beta3
- * @see <a href="https://omero.readthedocs.io/en/stable/developers/Search/FileParsers.html">Parsers</a
- *      href>
- * @see <a href="https://omero.readthedocs.io/en/stable/developers/Modules/Search/Bridges.html">Bridges</a
- *      href>
+ * @see <a href="https://omero.readthedocs.io/en/stable/developers/Search/FileParsers.html">Parsers</a>
+ * @see <a href="https://omero.readthedocs.io/en/stable/developers/Modules/Search/Bridges.html">Bridges</a>
  */
 @Deprecated
 public class FullTextBridge extends BridgeHelper {
@@ -101,8 +99,7 @@ public class FullTextBridge extends BridgeHelper {
      *            set of {@link FieldBridge bridge classes} which will be
      *            instantiated via a no-arg constructor.
      * @see <a
-     *      href="https://omero.readthedocs.io/en/stable/developers/Modules/Search/Bridges.html">Bridges</a
-     *      href>
+     *      href="https://omero.readthedocs.io/en/stable/developers/Modules/Search/Bridges.html">Bridges</a>
      */
     @SuppressWarnings("unchecked")
     public FullTextBridge(OriginalFilesService files,
@@ -124,8 +121,7 @@ public class FullTextBridge extends BridgeHelper {
      * @param maxFilesetSize
      *            maximum size of the fileset to be considered for indexing
      * @see <a
-     *      href="https://omero.readthedocs.io/en/stable/developers/Modules/Search/Bridges.html">Bridges</a
-     *      href>
+     *      href="https://omero.readthedocs.io/en/stable/developers/Modules/Search/Bridges.html">Bridges</a>
      */
     @SuppressWarnings("unchecked")
     public FullTextBridge(OriginalFilesService files,

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -114,7 +114,7 @@ public class FullTextBridge extends BridgeHelper {
      * @param maxFilesetSize the maximume fileset size
      */
     public void setMaxFilesetSize(int maxFilesetSize) {
-        logger().info("Setting maximum fileset size: {}", maxFilesetSize);
+        logger().info("Setting maximum fileset size to {}", maxFilesetSize);
         this.maxFilesetSize = maxFilesetSize;
     }
 
@@ -405,21 +405,29 @@ public class FullTextBridge extends BridgeHelper {
             if (fileset == null) {
                 return;
             }
-            // Skip fileset indexing above a cut-off
-            // As the fileset indexing scales with the number of fileset entries for each
-            // image, this operation can quickly lead to performance degradation notable
-            // in domains like high-content screening where each of 1K-10K images in a plate
-            // can be associated with 10-100K files
-            if (fileset.sizeOfUsedFiles() > maxFilesetSize) {
-              return;
+
+            if (maxFilesetSize > 0) {
+              add(document, "fileset.templatePrefix", fileset.getTemplatePrefix(), opts);
             }
-            add(document, "fileset.templatePrefix", fileset.getTemplatePrefix(), opts);
+
             final Iterator<FilesetEntry> entryIterator = fileset.iterateUsedFiles();
+            int index = 0;
             while (entryIterator.hasNext()) {
                 final FilesetEntry entry = entryIterator.next();
                 if (entry == null) {
                     continue;
                 }
+
+                // Skip fileset indexing above a cut-off
+                // As the fileset indexing scales with the number of fileset entries for each
+                // image, this operation can quickly lead to performance degradation notable
+                // in domains like high-content screening where each of 1K-10K images in a plate
+                // can be associated with 10-100K files
+                index++;
+                if (index > maxFilesetSize) {
+                  return;
+                }
+
                 add(document, "fileset.entry.clientPath", entry.getClientPath(), opts);
                 add(document, "fileset.entry.name", entry.getOriginalFile().getName(), opts);
             }

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -425,9 +425,11 @@ public class FullTextBridge extends BridgeHelper {
             if (fileset == null) {
                 return;
             }
-            // Skip indexing of filesets with multiple files
-            // This is particularly important for HCS file formats where the indexing time
-            // as well as the size of the FullText can grow exponentially with plate sizes
+            // Skip fileset indexing above a cut-off
+            // As the fileset indexing scales with the number of fileset entries for each
+            // images, this operation can quickly lead to performance degradation notable
+            // in domains like high-content screening where each of 1K-10K images in a plate
+            // can be associated with 10-100K files
             if (fileset.sizeOfUsedFiles() > maxFilesetSize) {
               return;
             }

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -423,7 +423,7 @@ public class FullTextBridge extends BridgeHelper {
             }
             // Skip fileset indexing above a cut-off
             // As the fileset indexing scales with the number of fileset entries for each
-            // images, this operation can quickly lead to performance degradation notable
+            // image, this operation can quickly lead to performance degradation notable
             // in domains like high-content screening where each of 1K-10K images in a plate
             // can be associated with 10-100K files
             if (fileset.sizeOfUsedFiles() > maxFilesetSize) {

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -433,6 +433,7 @@ public class FullTextBridge extends BridgeHelper {
             if (fileset.sizeOfUsedFiles() > maxFilesetSize) {
               return;
             }
+            add(document, "fileset.templatePrefix", fileset.getTemplatePrefix(), opts);
             final Iterator<FilesetEntry> entryIterator = fileset.iterateUsedFiles();
             while (entryIterator.hasNext()) {
                 final FilesetEntry entry = entryIterator.next();
@@ -441,7 +442,6 @@ public class FullTextBridge extends BridgeHelper {
                 }
                 add(document, "fileset.entry.clientPath", entry.getClientPath(), opts);
                 add(document, "fileset.entry.name", entry.getOriginalFile().getName(), opts);
-                add(document, "fileset.templatePrefix", fileset.getTemplatePrefix(), opts);
             }
         }
     }

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -402,13 +402,11 @@ public class FullTextBridge extends BridgeHelper {
         if (object instanceof Image) {
             final Image image = (Image) object;
             final Fileset fileset = image.getFileset();
-            if (fileset == null) {
+            if (fileset == null || maxFilesetSize < 1) {
                 return;
             }
 
-            if (maxFilesetSize > 0) {
-              add(document, "fileset.templatePrefix", fileset.getTemplatePrefix(), opts);
-            }
+            add(document, "fileset.templatePrefix", fileset.getTemplatePrefix(), opts);
 
             final Iterator<FilesetEntry> entryIterator = fileset.iterateUsedFiles();
             int index = 0;
@@ -425,7 +423,7 @@ public class FullTextBridge extends BridgeHelper {
                 // can be associated with 10-100K files
                 index++;
                 if (index > maxFilesetSize) {
-                  return;
+                    return;
                 }
 
                 add(document, "fileset.entry.clientPath", entry.getClientPath(), opts);

--- a/src/main/java/ome/services/fulltext/FullTextBridge.java
+++ b/src/main/java/ome/services/fulltext/FullTextBridge.java
@@ -55,9 +55,9 @@ import java.util.Map;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 3.0-Beta3
- * @see <a href="https://trac.openmicroscopy.org.uk/ome/FileParsers">Parsers</a
+ * @see <a href="https://omero.readthedocs.io/en/stable/developers/Search/FileParsers.html">Parsers</a
  *      href>
- * @see <a href="https://trac.openmicroscopy.org.uk/ome/SearchBridges">Bridges</a
+ * @see <a href="https://omero.readthedocs.io/en/stable/developers/Modules/Search/Bridges.html">Bridges</a
  *      href>
  */
 @Deprecated
@@ -101,7 +101,7 @@ public class FullTextBridge extends BridgeHelper {
      *            set of {@link FieldBridge bridge classes} which will be
      *            instantiated via a no-arg constructor.
      * @see <a
-     *      href="https://trac.openmicroscopy.org.uk/ome/SearchBridges">Bridges</a
+     *      href="https://omero.readthedocs.io/en/stable/developers/Modules/Search/Bridges.html">Bridges</a
      *      href>
      */
     @SuppressWarnings("unchecked")
@@ -124,7 +124,7 @@ public class FullTextBridge extends BridgeHelper {
      * @param maxFilesetSize
      *            maximum size of the fileset to be considered for indexing
      * @see <a
-     *      href="https://trac.openmicroscopy.org.uk/ome/SearchBridges">Bridges</a
+     *      href="https://omero.readthedocs.io/en/stable/developers/Modules/Search/Bridges.html">Bridges</a
      *      href>
      */
     @SuppressWarnings("unchecked")

--- a/src/main/resources/ome/services/service-ome.api.Search.xml
+++ b/src/main/resources/ome/services/service-ome.api.Search.xml
@@ -52,6 +52,7 @@
     <constructor-arg ref="fileParsers"/>
     <constructor-arg ref="/OMERO/Files"/>
     <constructor-arg value="${omero.search.bridges}"/>
+    <constructor-arg value="${omero.search.max_fileset_size}"/>
   </bean>
   
   <!-- Use "*" as a wildcard parser -->

--- a/src/main/resources/ome/services/service-ome.api.Search.xml
+++ b/src/main/resources/ome/services/service-ome.api.Search.xml
@@ -52,7 +52,7 @@
     <constructor-arg ref="fileParsers"/>
     <constructor-arg ref="/OMERO/Files"/>
     <constructor-arg value="${omero.search.bridges}"/>
-    <constructor-arg value="${omero.search.max_fileset_size}"/>
+    <property name="maxFilesetSize" value="${omero.search.max_fileset_size}"/>
   </bean>
   
   <!-- Use "*" as a wildcard parser -->

--- a/src/main/resources/omero-server.properties
+++ b/src/main/resources/omero-server.properties
@@ -197,6 +197,8 @@ ome.model.screen.PlateAcquisition,ome.model.screen.Well
 # modified.
 omero.search.include_actions=INSERT,UPDATE,REINDEX,DELETE
 
+# Maximum size of the fileset to be considered for indexing
+omero.search.max_fileset_size=1
 
 ##
 ## Old loader: "persistentEventLogLoader"

--- a/src/main/resources/omero-server.properties
+++ b/src/main/resources/omero-server.properties
@@ -197,10 +197,11 @@ ome.model.screen.PlateAcquisition,ome.model.screen.Well
 # modified.
 omero.search.include_actions=INSERT,UPDATE,REINDEX,DELETE
 
-# Maximum size of the fileset to consider for indexing
+# Maximum number of fileset entries which will be indexed
 # Increasing this cut-off can lead to indexing performance degradation
 # notably in the high-content screening domain where plates typically
 # contain 1K-10K images associated with 10-100K fileset entries each
+# If set to 0, no fileset entry will be indexed
 omero.search.max_fileset_size=10
 
 ##

--- a/src/main/resources/omero-server.properties
+++ b/src/main/resources/omero-server.properties
@@ -201,7 +201,7 @@ omero.search.include_actions=INSERT,UPDATE,REINDEX,DELETE
 # Increasing this cut-off can lead to indexing performance degradation
 # notably in the high-content screening domain where plates typically
 # contain 1K-10K images associated with 10-100K fileset entries each
-omero.search.max_fileset_size=1
+omero.search.max_fileset_size=10
 
 ##
 ## Old loader: "persistentEventLogLoader"

--- a/src/main/resources/omero-server.properties
+++ b/src/main/resources/omero-server.properties
@@ -197,7 +197,10 @@ ome.model.screen.PlateAcquisition,ome.model.screen.Well
 # modified.
 omero.search.include_actions=INSERT,UPDATE,REINDEX,DELETE
 
-# Maximum size of the fileset to be considered for indexing
+# Maximum size of the fileset to consider for indexing
+# Increasing this cut-off can lead to indexing performance degradation
+# notably in the high-content screening domain where plates typically
+# contain 1K-10K images associated with 10-100K fileset entries each
 omero.search.max_fileset_size=1
 
 ##


### PR DESCRIPTION
## Context

As part of the OMERO 5.5.0 release, the indexing logic was fully rewritten to use a new `FullTextIndexer2` (initial work in https://github.com/ome/omero-server/pull/10). While performing with a background reindexing as described in [the documentation](https://omero.readthedocs.io/en/stable/sysadmins/search.html#re-indexing), we noticed the reindexing progress was extremely slow roughly with a rate of ~1%/day, meaning the process would take months to complete. Additionally, this trend suggests that even on completion, the indexer would be unlikely to catch-up with new imports.

The system where the issue was identified is almost exclusively composed of HCS data. After some investigation, the source of the performance issue was traced down to the features introduced in https://github.com/ome/omero-server/pull/57, more specifically the indexing of filesets associated with images. The review suggests that most of the testing was carried out either with single-file filesets or filesets with a few entries. Under these conditions, the new operation will add a manageable overhead for every image indexed. However, when dealing with multi-image filesets, this operation will typically scale as n_images x m_entries. This becomes particularly critical in the high-content screening domain where plates are routinely composed of 1-10K images and 10-100K fileset entries. There are three related problems:

- the performance degradation associated with the indexing process
- the growth of the content of `FullText` under the binary repository
- the value of the feature in the particular domain since most HCS formats use fairly standard filenames e.g. `r01c01f01p01-ch1sk1fk1fl1.tiff` which will be associated to all images in each plate

## Proposal

To mitigate the HCS issue without fully disabling the functionality introduced previously, this PR  introduces a server side property `omero.search.max_fileset_size` which defines a cut-off above which fileset entries are not indexed. The default value is arbitrarily set to 1 i.e. only single-file filesets will be indexed but is up for discussion.

## Testing

Data-wise, the BBBC017 plate is a good representative sample for reproducing this issue and assessing the proposed solution. This is a fairly standard plate (384 wells, 6 fields of views/well) that has been converted into two variants of OME-TIFF: single file and multi-file with companion - see https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/BBBC017/. Both datasets are strictly identical in terms of metadata and only differ by their number of constituent files (1 vs 2304).

Testing should ideally be carried out from an empty database or from a populated one after recording the base reindexing time. After importing each variant of the plate mentioned above, the database should be reindexing following the instructions of the documentation and the reindexing time should be measured using the timestamps in the `Indexer-0.log`.

My own measurements are given below for reference but the reindexing performance might vary depending on the system. The absolute reindexing values are less important than the ratio between the reindexing time between a single-file plate and a multi-file plate.

Without this PR, the reindexing time were found to be 15s for the single-file OME-TIFF plate versus 180s for the multi-file OME-TIFF plate.

With this PR included, the reindexing time should be identical and equal to 15s for both plates.

/cc @chris-allan @stick 