### PR TITLE
push to releases

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,7 +28,7 @@ jobs:
     uses: ome/action-workflows/.github/workflows/gradle_publish.yml@v1.2
     with:
       install-ice: true
-      ARTIFACTORY_URL: "staging"
+      ARTIFACTORY_URL: "releases"
     secrets:
       ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
       ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}


### PR DESCRIPTION
In order to allow team member with push rights to release component, this PR changes where the jar is pushed to https://artifacts.openmicroscopy.org/
This will avoid the creation of new account, this follows the same pattern that the one used for Python packages