### PR TITLE
Fix context initialization for server extensions

### DIFF
--- a/src/main/resources/beanRefContext.xml
+++ b/src/main/resources/beanRefContext.xml
@@ -46,7 +46,6 @@
         <value>classpath:ome/services/messaging.xml</value>
         <value>classpath:ome/services/checksum.xml</value>
         <value>classpath:ome/services/datalayer.xml</value>
-        <value>classpath*:ome/services/db-*.xml</value>
         <value>classpath:ome/services/sec-primitives.xml</value>
         <value>classpath:ome/services/hibernate.xml</value>
         <value>classpath:ome/services/services.xml</value>
@@ -54,6 +53,7 @@
         <value>classpath:ome/services/sec-system.xml</value>
         <value>classpath:ome/services/startup.xml</value>
         <!-- Allow user added files -->
+        <value>classpath*:ome/services/db-*.xml</value>
         <value>classpath*:blitz/*.xml</value>
       </list>
     </constructor-arg>


### PR DESCRIPTION
This PR aims to address an issue with OMERO.server extension point which prevents the server from starting. 

https://github.com/sbesson/omero-passwordprovider-extension contains a minimal reproducible example of such an extension containing a single no-op class extending `ConfigurablePasswordProvider` as well as a Spring XML configuration file following the recommendations of https://omero.readthedocs.io/en/stable/developers/Server/PasswordProvider.html and https://omero.readthedocs.io/en/stable/developers/Server/ExtendingOmero.html

After building the JAR (`./gradlew build`) and copying it under `lib/server` or OMERO.server 5.6.6 and issuing `omero admin restart`, the server should fail to start up with the following exception indicating a circular dependency:

<details>
    <summary>Blitz-0.log error</summary>

    2023-03-08 11:19:49,874 WARN  [                 ome.system.OmeroContext] (      main) Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'noopPasswordProvider' defined in URL [jar:file:/opt/OMERO.server-5.6.5-ice36-b233/lib/server/omero-passwordprovider-extension-0.1.0-SNAPSHOT.jar!/ome/services/db-noopprovider.xml]: Cannot resolve reference to bean 'passwordUtil' while setting constructor argument; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'passwordUtil' defined in URL [jar:file:/opt/OMERO.server-5.6.5-ice36-b233/lib/server/omero-server.jar!/ome/services/service-ome.api.IAdmin.xml]: Cannot resolve reference to bean 'internal-ome.api.IQuery' while setting bean property 'queryService'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'internal-ome.api.IQuery' defined in URL [jar:file:/opt/OMERO.server-5.6.5-ice36-b233/lib/server/omero-server.jar!/ome/services/service-ome.api.IQuery.xml]: Cannot resolve reference to bean 'timeoutSetter' while setting bean property 'timeoutSetter'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'timeoutSetter' defined in class path resource [ome/services/services.xml]: Cannot resolve reference to bean 'securitySystem' while setting constructor argument; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'basicSecuritySystem' defined in class path resource [ome/services/sec-system.xml]: Cannot resolve reference to bean 'sessionManager' while setting constructor argument; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'sessionManager' defined in class path resource [ome/services/sec-primitives.xml]: Cannot resolve reference to bean 'executor' while setting bean property 'executor'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'executor' defined in class path resource [ome/services/services.xml]: Initialization of bean failed; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'eventHandler' defined in class path resource [ome/services/sec-system.xml]: Cannot resolve reference to bean 'basicSecuritySystem' while setting constructor argument; nested exception is org.springframework.beans.factory.BeanCurrentlyInCreationException: Error creating bean with name 'basicSecuritySystem': Requested bean is currently in creation: Is there an unresolvable circular reference?
</details>

This PR proposes to address initialisation error  by moving `ome/services/db-*.xml` to the bottom of the list of services alongside the other user-added files. This should allow the core services (`sec-system.xml` specifically in the example above) to be initialized first and used by the new service.

Using an  OMERO.server bundle including this change as well as the password provider extension JAR under `lib/server`, the following changes should be tested in two configurations:
-  `omero.security.password_provider` unset
-  `omero.security.password_provider` set to `chainedPasswordProviderNoop`
For both configurations, the server and all services should initialize successfully. Additionally, a a minimal `omero login root@localhost -w omero -C` should confirm the authentication logic is functional (the new provider is a no-op and should delegate all password checks to the `jdbcPasswordProvider` class)