### PR TITLE
Histogram: fix bin assignment computation

### DIFF
--- a/src/main/java/ome/services/RawPixelsBean.java
+++ b/src/main/java/ome/services/RawPixelsBean.java
@@ -746,21 +746,22 @@ public class RawPixelsBean extends AbstractStatefulBean implements
                 double min = minmax[0];
                 double max = minmax[1];
 
-                double range = max - min + 1;
+                double range = max - min;
                 double binRange = range / binCount;
                 for (int i = 0; i < px.size(); i++) {
                     int pxx = i % imgWidth;
                     int pxy = i / imgWidth;
                     if (pxx >= x && pxx < (x + w) && pxy >= y && pxy < (y + h)) {
-                        int bin = (int) ((px.getPixelValue(i) - min) / binRange);
-                        // if there are more bins than values (binRange < 1) the bin will be offset by -1.
-                        // e.g. min=0.0, max=127.0, binCount=256: a pixel with max value 127.0 would go
-                        // into bin 254 (expected: 255). Therefore increment by one for these cases.
-                        if (bin > 0 && binRange < 1)
-                            bin++;
-
-                        if (bin >= 0 && bin < binCount)
+                        if (px.getPixelValue(i) < min || px.getPixelValue(i) > max) {
+                            continue;
+                        } else {
+                            int bin = (int) ((px.getPixelValue(i) - min) / binRange);
+                            // Handle values exactly at the last edge
+                            if (bin == binCount) {
+                                bin--;
+                            }
                             data[bin]++;
+                        }
                     }
                 }
                 result.put(ch, data);


### PR DESCRIPTION
The previous computation was using a range with an additional increment of 1 and a correction step in the loop. While this was mostly generating acceptable for integer pixel types especially for large values, the histogram was particularly incorrect for floating point values e.g. in the `[-1.0, 1.0]` range.

This PR ports the histogram computation change proposed  in https://github.com/glencoesoftware/omero-ms-image-region/pull/128 which largely replicates the implementation of `numpy.histogram` to the OMERO.server implementation.

https://github.com/ome/openmicroscopy/pull/6350 has been opened separately to fix the existing histogram integration tests as well as adding tests for other pixel types (int8, int16).

Proposing this for a patch release of the `omero-server` component