### PR TITLE
Experimenter group cache

### DIFF
--- a/src/main/java/ome/security/basic/EventListenersFactoryBean.java
+++ b/src/main/java/ome/security/basic/EventListenersFactoryBean.java
@@ -46,18 +46,18 @@ public class EventListenersFactoryBean extends AbstractFactoryBean {
 
     private final OmeroInterceptor interceptor;
 
-    private final ExperimenterGroupCache cache;
+    private final ExperimenterGroupCache experimenterGroupCache;
 
     // ~ FactoryBean
     // =========================================================================
 
     public EventListenersFactoryBean(CurrentDetails cd, TokenHolder th,
-            ACLVoter voter, OmeroInterceptor interceptor, ExperimenterGroupCache cache) {
+            ACLVoter voter, OmeroInterceptor interceptor, ExperimenterGroupCache experimenterGroupCache) {
         this.cd = cd;
         this.th = th;
         this.voter = voter;
         this.interceptor = interceptor;
-        this.cache = cache;
+        this.experimenterGroupCache = experimenterGroupCache;
     }
 
     /**
@@ -168,7 +168,7 @@ public class EventListenersFactoryBean extends AbstractFactoryBean {
         append("post-delete", ell);
 
         PermissionsCacheEventListener pcel =
-                new ome.security.basic.PermissionsCacheEventListener(cache);
+                new ome.security.basic.PermissionsCacheEventListener(experimenterGroupCache);
         append("post-insert", pcel);
         append("post-update", pcel);
         append("post-delete", pcel);

--- a/src/main/java/ome/security/basic/EventListenersFactoryBean.java
+++ b/src/main/java/ome/security/basic/EventListenersFactoryBean.java
@@ -46,15 +46,18 @@ public class EventListenersFactoryBean extends AbstractFactoryBean {
 
     private final OmeroInterceptor interceptor;
 
+    private final ExperimenterGroupCache cache;
+
     // ~ FactoryBean
     // =========================================================================
 
     public EventListenersFactoryBean(CurrentDetails cd, TokenHolder th,
-            ACLVoter voter, OmeroInterceptor interceptor) {
+            ACLVoter voter, OmeroInterceptor interceptor, ExperimenterGroupCache cache) {
         this.cd = cd;
         this.th = th;
         this.voter = voter;
         this.interceptor = interceptor;
+        this.cache = cache;
     }
 
     /**
@@ -163,6 +166,12 @@ public class EventListenersFactoryBean extends AbstractFactoryBean {
         append("post-insert", ell);
         append("post-update", ell);
         append("post-delete", ell);
+
+        PermissionsCacheEventListener pcel =
+                new ome.security.basic.PermissionsCacheEventListener(cache);
+        append("post-insert", pcel);
+        append("post-update", pcel);
+        append("post-delete", pcel);
 
         UpdateEventListener uel = new UpdateEventListener(cd);
         append("pre-update", uel);

--- a/src/main/java/ome/security/basic/ExperimenterGroupCache.java
+++ b/src/main/java/ome/security/basic/ExperimenterGroupCache.java
@@ -1,0 +1,12 @@
+package ome.security.basic;
+
+import java.sql.SQLException;
+
+public interface ExperimenterGroupCache {
+    
+    public void updateCache() throws SQLException;
+    
+    public boolean cacheIsValid();
+
+    public boolean isRelatedUser(long experimenterId, long currentUserId, long userGroupId);
+}

--- a/src/main/java/ome/security/basic/InMemoryExperimenterGroupCache.java
+++ b/src/main/java/ome/security/basic/InMemoryExperimenterGroupCache.java
@@ -1,0 +1,105 @@
+package ome.security.basic;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.hibernate.event.PostDeleteEvent;
+import org.hibernate.event.PostDeleteEventListener;
+import org.hibernate.event.PostInsertEvent;
+import org.hibernate.event.PostInsertEventListener;
+import org.hibernate.event.PostUpdateEvent;
+import org.hibernate.event.PostUpdateEventListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InMemoryExperimenterGroupCache implements ExperimenterGroupCache {
+
+    private final DataSource dataSource;
+    public Map<Long, List<Long>> groupMembership = new HashMap<Long, List<Long>>();
+    public Map<Long, Long> groupPermissions = new HashMap<Long, Long>();
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private boolean isValid;
+    
+    public InMemoryExperimenterGroupCache(DataSource dataSource) throws SQLException {
+        this.dataSource = dataSource;
+        updateCache();
+        log.info(Integer.toString(groupMembership.size()));
+        log.info(Integer.toString(groupPermissions.size()));
+    }
+
+    @Override
+    public synchronized boolean isRelatedUser(long experimenterId, long currentUserId,
+            long userGroupId) {
+        log.info("In isRelatedUser in cache!!!");
+        List<Long> experimenterGroups = groupMembership.get(experimenterId);
+        List<Long> currentUserGroups = groupMembership.get(currentUserId);
+        if (experimenterGroups == null || currentUserGroups == null) {
+            log.error("Failed to find groups for " + Long.toString(experimenterId) +
+                " or " + Long.toString(currentUserId));
+            return false;
+        }
+        boolean isRelated = false;
+        for (Long groupId : experimenterGroups) {
+            if (groupId.equals(userGroupId)) {
+                continue;
+            }
+            if (currentUserGroups.contains(groupId)) {
+                isRelated = true;
+                break;
+            }
+        }
+        return isRelated;
+    }
+    
+    @Override
+    public synchronized void updateCache() {
+        log.info("Updating permissions cache");
+        Map<Long, List<Long>> newGroupMembership = new HashMap<Long, List<Long>>();
+        Map<Long, Long> newGroupPermissions = new HashMap<Long, Long>();
+        try (final Connection connection = dataSource.getConnection()) {
+            final PreparedStatement statement = connection.prepareStatement(
+                    "SELECT parent, child FROM GroupExperimenterMap");
+            ResultSet results = statement.executeQuery();
+            while (results.next()) {
+                long groupId = results.getLong("parent");
+                long experimenterId = results.getLong("child");
+                if (!newGroupMembership.containsKey(experimenterId)) {
+                    newGroupMembership.put(experimenterId, new ArrayList<Long>());
+                }
+                newGroupMembership.get(experimenterId).add(groupId);
+            }
+            statement.close();
+            final PreparedStatement permissionsStatement = connection.prepareStatement(
+                "SELECT id, permissions FROM ExperimenterGroup");
+            ResultSet permResults = permissionsStatement.executeQuery();
+            while (permResults.next()) {
+                long groupId = permResults.getLong("id");
+                long permissions = permResults.getLong("permissions");
+                newGroupPermissions.put(groupId, permissions);
+            }
+            permissionsStatement.close();
+        } catch (SQLException e) {
+            log.error("Error updating experimenter group cache", e);
+            isValid = false;
+            return;
+        }
+        groupMembership = newGroupMembership;
+        groupPermissions = newGroupPermissions;
+        isValid = true;
+    }
+
+    @Override
+    public synchronized boolean cacheIsValid() {
+        return isValid;
+    }
+}

--- a/src/main/java/ome/security/basic/PermissionsCacheEventListener.java
+++ b/src/main/java/ome/security/basic/PermissionsCacheEventListener.java
@@ -1,0 +1,60 @@
+package ome.security.basic;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.event.PostDeleteEvent;
+import org.hibernate.event.PostDeleteEventListener;
+import org.hibernate.event.PostInsertEvent;
+import org.hibernate.event.PostInsertEventListener;
+import org.hibernate.event.PostUpdateEvent;
+import org.hibernate.event.PostUpdateEventListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PermissionsCacheEventListener
+        implements PostUpdateEventListener, PostInsertEventListener,
+        PostDeleteEventListener {
+    
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    
+    private ExperimenterGroupCache cache;
+    
+    private List<String> relevantClassNames;
+    
+    PermissionsCacheEventListener(ExperimenterGroupCache cache) {
+        this.cache = cache;
+        relevantClassNames = new ArrayList<String>();
+        relevantClassNames.add("GroupExperimenterMap");
+        relevantClassNames.add("Experimenter");
+        relevantClassNames.add("ExperimenterGroup");
+    }
+    
+    private void conditionallyUpdateCache(String className) {
+        log.debug(className);
+        if (relevantClassNames.contains(className)) {
+            try {
+                cache.updateCache();
+            } catch (SQLException e) {
+                log.error("Error updating ExperimenterGroupCache", e);
+            }
+        }
+    }
+
+    @Override
+    public void onPostDelete(PostDeleteEvent event) {
+        conditionallyUpdateCache(event.getEntity().getClass().getSimpleName());
+    }
+
+    @Override
+    public void onPostInsert(PostInsertEvent event) {
+        conditionallyUpdateCache(event.getEntity().getClass().getSimpleName());
+    }
+
+    @Override
+    public void onPostUpdate(PostUpdateEvent event) {
+        conditionallyUpdateCache(event.getEntity().getClass().getSimpleName());
+    }
+
+}

--- a/src/main/resources/ome/services/sec-primitives.xml
+++ b/src/main/resources/ome/services/sec-primitives.xml
@@ -80,6 +80,11 @@
     <constructor-arg ref="currentDetails"/>
     <constructor-arg ref="dataSource"/>
     <constructor-arg ref="roles"/>
+    <constructor-arg ref="experimenterGroupCache"/>
+  </bean>
+
+  <bean id="experimenterGroupCache" class="ome.security.basic.InMemoryExperimenterGroupCache">
+	  <constructor-arg ref="dataSource"/>
   </bean>
 
   <bean id="sqlQueryTransformer" class="ome.tools.hibernate.SqlQueryTransformer" depends-on="initPropertyFilters">

--- a/src/main/resources/ome/services/sec-system.xml
+++ b/src/main/resources/ome/services/sec-system.xml
@@ -89,6 +89,7 @@
     <constructor-arg ref="currentDetails"/>
     <constructor-arg ref="tokenHolder"/>
     <constructor-arg ref="omeroInterceptor"/>
+    <constructor-arg ref="experimenterGroupCache"/>
     <property name="debugAll" value="false"/>
   </bean>
 


### PR DESCRIPTION
Fixes #165.
Creates a simple in-memory cache which contains all the relevant data in the ExperimenterGroup and ExperimenterGroupMap tables to perform the `isRelatedUser` check. 
Some things that still need to be implemented/fixed:
 - Updating a group's permissions (e.g. from Private to ReadOnly) does not seem to create an event with entity of type ExperimenterGroup as I expected. It does create one with an entity of Session, but I don't think we want to update the cache every time we get a Session event. I haven't figured out why this is or what to do about it.
 - I'm not entirely sure what to do if the cache fails to update and becomes invalid. Currently, I just flag it as invalid and it is ignored until it updates successfully. It's probably better than the server going down, but it also means that it's possible your server will experience a sudden decrease in performance and you have to go to the logs to figure out why.
 - I noticed that if you change a user to or from a group owner, it takes awhile for the event context to be updated and until then you may see incorrect responses when getting user data.
 - Need to write javadocs for everything

## Testing:
There are a few different scenarios which need to be tested:
 - Getting experimenter data as admin or group owner (should always succeed)
 - Getting experimenter data for a system user (should always succeed)
 - Getting experimenter data as a fellow group member (non-owner) of a group which is not private (should succeed)
 - Getting experimenter data as a fellow group member (non-owner) of a group which is private (should fail)
 - Getting experimenter data for a user with no groups in common (should fail)
 - Creating a group should update the cache
 - Creating a user should update the cache
 - Adding a user to a group should update the cache
 - Removing a user from a group should update the cache
 - Changing group permissions should update the cache (currently it does NOT)
