### PR TITLE
Bump org.postgresql:postgresql to version 42.2.28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
     if (databaseType.equals("psql")) {
         // Postgres connect driver for java
-        implementation 'org.postgresql:postgresql:42.2.28'
+        implementation 'org.postgresql:postgresql:42.2.29'
     }
     // Used by hibernate, see: https://stackoverflow.com/a/14365438
     implementation("org.javassist:javassist:3.25.0-GA")

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
     if (databaseType.equals("psql")) {
         // Postgres connect driver for java
-        implementation 'org.postgresql:postgresql:42.2.1'
+        implementation 'org.postgresql:postgresql:42.2.28'
     }
     // Used by hibernate, see: https://stackoverflow.com/a/14365438
     implementation("org.javassist:javassist:3.25.0-GA")


### PR DESCRIPTION
See https://forum.image.sc/t/is-omero-using-pgjdbc/92549 for more context

Although there is no known path to exploit CVE-2024-1597 in our usage of the PostgreSQL JDBC driver, this proposes to update the dependency to include the security fix as well as other CVEs that have been addressed upstream.