### PR TITLE
Swap default min and background thread limits

### DIFF
--- a/src/main/resources/omero-server.properties
+++ b/src/main/resources/omero-server.properties
@@ -304,7 +304,7 @@ omero.sessions.max_user_time_to_live=0
 # priority level. Internal system threads may still run.
 # Note when setting this that these threads do not
 # time out.
-omero.threads.min_threads=5
+omero.threads.min_threads=10
 
 # This setting does nothing.
 # See https://github.com/ome/omero-server/issues/154
@@ -323,7 +323,7 @@ omero.threads.max_threads=50
 # import. Note that if this value is less than min_threads,
 # min_threads will limit the number of background
 # tasks which can run simultaneously.
-omero.threads.background_threads=10
+omero.threads.background_threads=5
 
 # Number of milliseconds to wait for a slot in the
 # background queue before a rejection error will be


### PR DESCRIPTION
Having the background counting semaphore count greater than the minimum thread count (which is actually the __maximum__) can cause the server to lock up when background tasks consume all these threads. Here we are switching these defaults so that's no longer possible. The only downside to this change is that the background counting semaphore will now be exhausted at 5 tasks rather than 10.

This is an interim solution to #159.