### PR TITLE
Replace usage of Apache Commons Library by SL4J

### DIFF
--- a/src/main/java/ome/services/util/JvmSettingsCheck.java
+++ b/src/main/java/ome/services/util/JvmSettingsCheck.java
@@ -28,8 +28,8 @@ import java.lang.management.ManagementFactory;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
 
@@ -42,7 +42,7 @@ import com.google.common.base.Joiner;
  */
 public class JvmSettingsCheck {
 
-    public final static Log log = LogFactory.getLog(JvmSettingsCheck.class);
+    public final static Logger log = LoggerFactory.getLogger(JvmSettingsCheck.class);
 
     /**
      * TotalPhysicalMemorySize value from the OperatingSystem JMX bean


### PR DESCRIPTION
See https://github.com/ome/openmicroscopy/issues/6416

This should remove the requirement to include a bridging JAR in the server distribution

To test this, restart the server and make sure the Blitz log includes the logging statements about Java version, memory, processors