### PR TITLE
Fix group-level parsing of omero.policy.binary_access

### DIFF
--- a/src/main/java/ome/security/policy/BinaryAccessPolicy.java
+++ b/src/main/java/ome/security/policy/BinaryAccessPolicy.java
@@ -165,8 +165,9 @@ public class BinaryAccessPolicy extends BasePolicy {
                     if (rv == null) {
                         rv = new HashSet<String>();
                     }
-                    String setting = nv.getValue();
-                    rv.add(setting);
+                    for (String setting : nv.getValue().split(",")) {
+                        rv.add(setting);
+                    }
                 }
             }
             if (rv != null) {


### PR DESCRIPTION
Discovered while investigating https://github.com/ome/omero-cli-transfer on plates. Based on the [documentation](https://omero.readthedocs.io/en/stable/sysadmins/customization.html#download-restrictions), I expected `omero obj map-set ExperimenterGroup:<id> config -- omero.policy.binary_access +read,+write,+image,+plate` to work but plate download was still restricted. As a workaround, setting `omero obj map-set ExperimenterGroup:<id> config -- omero.policy.binary_access +plate` worked as expected.

While the global policy is injected as a string array to the constructor and stored as a string set, the group-level policy read from the `Experimenter.config` map is a comma-separated string. In the current implementation, this value is stored directly in the group string set and the `contains` check in `notAorB` can be incorrect if multiple values are present. e3a97c491b5ab29d197a9863e3f64d5a5fcf13ec fixes this behavior by splitting `nv.getValue()` using comma as a separator and adding the individual entries to the group restriction string set.

This PR can be tested functionally on a standard OMERO deployment by testing the download of an image imported by a user in a group. Download can be tested using the OMERO.web UI or a plugin like `omero download`

- with the default server binary policy (`+read, +write, +image`) and no group-level binary configuration, image download should be allowed
- with `-write` as the group binary policy (`omero obj map-set ExperimenterGroup:<id> config -- omero.policy.binary_access -write`), image download should be disallowed
- with `-image` as the group binary policy (`omero obj map-set ExperimenterGroup:<id> config -- omero.policy.binary_access -image`), image download should be disallowed
- with `-write,-image` as the group binary policy (`omero obj map-set ExperimenterGroup:<id> config -- omero.policy.binary_access -write,-image`), image download should be allowed without this PR but disallowed with this PR.

Additional tests can be performed against plates:
- using the default server binary policy and no group-level binary configuration, plate download should be disallowed
- with `+plate` as the group binary policy, plate download should be allowed
- with `+read,+write,+image,+plate` as the group binary policy, plate download should be disallowed without this PR but allowed with this PR
