### PR TITLE
Bump Spring Framework to 4.3.30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,10 @@ dependencies {
     api('org.openmicroscopy:omero-renderer:5.6.2')
 
     // Spring framework stuff
-    implementation("org.springframework:spring-context-support:4.3.14.RELEASE")
-    implementation("org.springframework:spring-jms:4.3.14.RELEASE")
-    implementation("org.springframework.security:spring-security-ldap:4.2.4.RELEASE")
+    implementation("org.springframework:spring-context-support:4.3.30.RELEASE")
+    implementation("org.springframework:spring-jms:4.3.30.RELEASE")
+    implementation("org.springframework.security:spring-security-ldap:4.2.20.RELEASE")
+    implementation("org.springframework.ldap:spring-ldap-core:2.3.8.RELEASE")
 
     if (databaseType.equals("psql")) {
         // Postgres connect driver for java


### PR DESCRIPTION
Companion to https://github.com/ome/omero-model/pull/115

## Upstream changes

### Spring Framework

All the components under the `org.springframework` group are upgraded to 4.3.30.RELEASE which is the latest release on the 4.3.x series. These should be patch releases with no significant API changes - the list of release notes is below

https://github.com/spring-projects/spring-framework/releases/tag/v4.3.15.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.16.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.17.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.18.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.19.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.20.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.21.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.22.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.23.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.24.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.25.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.26.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.27.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.28.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.29.RELEASE
https://github.com/spring-projects/spring-framework/releases/tag/v4.3.30.RELEASE

### Spring Security LDAP

`org.springframework-security:spring-security-ldap` is upgraded to 4.2.20.RELEASE which is the latest release on the 4.2.x series and is compatible with 4.3.30.RELEASE above. Here also these are patch releases with no significant API changes. I found release notes under:

https://java.libhunt.com/spring-security-changelog/4.2.5.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.6.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.7.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.8.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.9.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.10.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.11.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.12.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.13.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.14.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.15.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.16.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.17.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.18.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.19.RELEASE
https://java.libhunt.com/spring-security-changelog/4.2.20.RELEASE

### Spring Security LDAP Core


`org.springframework-security:spring-security-ldap:4.2.20.RELEASE`  depends on `org.springframework.ldap:spring-ldap-core:2.3.3.RELEASE`. As described in https://github.com/ome/openmicroscopy/issues/6383, this version causes issues when starting a server on Java 17+ due to the usage of internal classes. This proposes to also upgrade this component to `2.3.8.RELEASE` which is the latest patch release on the 2.3.x series and should include a fix

https://github.com/spring-projects/spring-ldap/releases/tag/2.3.3.RELEASE
https://github.com/spring-projects/spring-ldap/releases/tag/2.3.4.RELEASE
https://github.com/spring-projects/spring-ldap/releases/tag/2.3.4.RELEASE
https://github.com/spring-projects/spring-ldap/releases/tag/2.3.5.RELEASE
https://github.com/spring-projects/spring-ldap/releases/tag/2.3.6.RELEASE
https://github.com/spring-projects/spring-ldap/releases/tag/2.3.7.RELEASE
https://github.com/spring-projects/spring-ldap/releases/tag/2.3.8.RELEASE


## Testing

Spring is an essential components of the OMERO.server. A complete testing would almost touch every functionality of OMERO.server, several of which are being exercised by the nightly integration tests. Below are a couple of scenarios that are not necessarily covered by the Java and Python integration tests and could be reviewed manually

### Deployment & configurability

Spring is used for injecting OMERO.server properties into Java bean constructors. Testing should ensure that modifying some of the server properties, defined in https://omero.readthedocs.io/en/stable/sysadmins/config.html, and redeploying the server ends with the expected result.

### LDAP

`spring-security-ldap` and `spring-ldap` being part of the upgraded dependencies, testing should include the deployment of OMERO.server with the upgraded dependencies with an LDAP server for authentication and validate the minimal workflow (authentication, user creation on first login...). https://github.com/ome/docker-example-omero-ldap provides a starting point for deploying OMERO.server with an LDAP service via apacheds-container.

### Java 17

Optionally, with the changes above, it should be possible to start OMERO.server in a Java 17 or Java 21 environment with the only OMERO configuration requirement being to set `omero.jvmcfg.append` to `--add-opens java.base/java.lang=ALL-UNNAMED` (for the btm dependency as described in https://github.com/ome/openmicroscopy/issues/6383)