### PR TITLE
Bump ehcache to version 2.10.9.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
         exclude group: 'javax.mail'
     }
 
-    implementation("net.sf.ehcache:ehcache:2.10.4")
+    implementation("net.sf.ehcache:ehcache:2.10.9.2")
 
     implementation("commons-io:commons-io:2.6")
 }


### PR DESCRIPTION
## Upstream changes

This PR bumps the verion of `net.sf.ehcache:ehcache` to the latest available version on the `2.10.x` series is the latest  available from Maven Central. This version  bundles a more recent version of the jackson-bind library included in the shaded. I could not find release notes for the 2.10.x series but the full diff of the source changes between the two versions https://github.com/ehcache/ehcache2/compare/v2.10.4..v2.10.9.2

## Testing

`ehcache` is the library used for managing server sessions as described in https://omero.readthedocs.io/en/stable/developers/Server/Sessions.html.

With this change included, the typical sessions workflow should remain functional including creating session, retrieving session key and rejoining using the session UUIDs.
Testing should also check rejoining a session after closing the initial session behaves as expected depending  on whether `detachOnDestroy` or `closeOnDestroy` has been called.

## Future work

Ehcache 2.x is EOL since September 2023. Future effort might look into migrating to Ehcache 3.x which development is happening in https://github.com/ehcache/ehcache3 and publication coordinates are `org.ehcache:ehcache`. A migration guide is available at https://www.ehcache.org/documentation/3.10/migration-guide.html.