### PR TITLE
Bump org.quartz-scheduler:quartz to 2.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
     implementation("com.mortennobel:java-image-scaling:0.8.6")
 
-    implementation("org.quartz-scheduler:quartz:2.2.1")
+    implementation("org.quartz-scheduler:quartz:2.4.0")
 
     implementation("org.subethamail:subethasmtp:3.1.7") {
         exclude group: 'javax.mail'


### PR DESCRIPTION
See https://github.com/quartz-scheduler/quartz/releases/tag/v2.4.0, https://github.com/quartz-scheduler/quartz/releases/tag/v2.3.2 and https://github.com/quartz-scheduler/quartz/releases/tag/quartz-2.3.1 for a list of upstream changes. In addition to bug fixes, the latest version requires Java 8 which is also the minimal version for OMERO.server and upgrades its dependencies.

Quartz is used for scheduling various tasks server-side, some of these can be configured via the properties ending with `.cron` like the pixeldata processing, the script cache update or the indexing - see  https://omero.readthedocs.io/en/stable/sysadmins/config.html. The [Process Container Steward](https://github.com/glencoesoftware/omero-pc-steward) is an example of server extension that uses the job scheduling functionality.

Testing-wise, all of these operations listed should remain functional and run on scheduled with the upgraded `quartz`. It would be useful to verify that modifying a cron expression via OMERO configuration results in the expected change in the execution frequency.
