### PR TITLE
Bump com.jamonapi:jamon to 2.82 and declare as a test dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation("org.javassist:javassist:3.25.0-GA")
 
     // API monitoring thing: http://jamonapi.sourceforge.net
-    implementation("com.jamonapi:jamon:2.81")
+    testImplementation("com.jamonapi:jamon:2.82")
 
     implementation("com.github.marcus-nl.btm:btm:3.0.0-mk1")
 


### PR DESCRIPTION
The com.jamonapi:jamon dependency was initially introduced in https://github.com/ome/openmicroscopy/commit/80e386893636fdf02236064a34e2d56cd2074a3c#diff-b2f6fbf7f1a6228bea217ac80cfa79daa242021b7873139a5a9af5d16fcd482a. The latest released version 2.82 transitively still depends on an old version of hazelcast-all.
From a search across the codebase, the library is neither used by the application at runtime nor mentioned in the OMERO documentation. Since some existing historical integration tests depend on it, this commit marks this dependency as test-only.