### PR TITLE
Only declare batik-codec as a dependency and upgrade to 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation("org.apache.calcite:calcite-core:1.20.0")
     implementation("org.apache.commons:commons-collections4:4.1")
     implementation("org.apache.pdfbox:pdfbox:2.0.8")
-    implementation("org.apache.xmlgraphics:batik-all:1.9.1")
+    implementation("org.apache.xmlgraphics:batik-codec:1.19")
 
     implementation("commons-beanutils:commons-beanutils:1.9.3")
 


### PR DESCRIPTION
The [Apache Batik project](https://xmlgraphics.apache.org/batik/) is a SVG toolkit primarily used in `ome.services.SVGRasterizer` and `ome.services.ThumbnailBean` for generating thumbnails. Currently `omero-server` depends on `batik-all` which includes a lot of unnecessary component and third-party dependencies.

This PR proposes to update this dependency to `batik-codec` which is the minimal component required for the SVG/JPEG transcoding ability. The dependency is also updated to 1.19 which is the latest release.

One immediate impact of this change should be to reduce the size of the OMERO.server artifact bundle by almost 20%. The nightly integration tests should keep passing.
Functional testing should ensure thumbnails are still generated and render as expected with different settings/channels.