### PR TITLE
Upgrade calcitecore to version 1.35

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 
     implementation("com.github.marcus-nl.btm:btm:3.0.0-mk1")
 
-    implementation("org.apache.calcite:calcite-core:1.20.0")
+    implementation("org.apache.calcite:calcite-core:1.39.0")
     implementation("org.apache.commons:commons-collections4:4.1")
     implementation("org.apache.pdfbox:pdfbox:2.0.8")
     implementation("org.apache.xmlgraphics:batik-all:1.9.1")

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 
     implementation("com.github.marcus-nl.btm:btm:3.0.0-mk1")
 
-    implementation("org.apache.calcite:calcite-core:1.39.0")
+    implementation("org.apache.calcite:calcite-core:1.35.0")
     implementation("org.apache.commons:commons-collections4:4.1")
     implementation("org.apache.pdfbox:pdfbox:2.0.8")
     implementation("org.apache.xmlgraphics:batik-all:1.9.1")
@@ -68,19 +68,6 @@ dependencies {
     implementation("net.sf.ehcache:ehcache:2.10.9.2")
 
     implementation("commons-io:commons-io:2.6")
-}
-
-// This workaround can be dropped when the build is upgraded to Gradle 7+
-// See https://github.com/google/guava/releases/tag/v32.1.0 and
-// https://github.com/google/guava/issues/6612#issuecomment-1614897285 for
-// more information
-sourceSets.all {
-  configurations.getByName(runtimeClasspathConfigurationName) {
-    attributes.attribute(Attribute.of("org.gradle.jvm.environment", String), "standard-jvm")
-  }
-  configurations.getByName(compileClasspathConfigurationName) {
-    attributes.attribute(Attribute.of("org.gradle.jvm.environment", String), "standard-jvm")
-  }
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,18 @@ dependencies {
     implementation("commons-io:commons-io:2.6")
 }
 
+// This workaround can be dropped when the build is upgraded to Gradle 7+
+// See https://github.com/google/guava/releases/tag/v32.1.0 and
+// https://github.com/google/guava/issues/6612#issuecomment-1614897285 for
+// more information
+sourceSets.all {
+  configurations.getByName(runtimeClasspathConfigurationName) {
+    attributes.attribute(Attribute.of("org.gradle.jvm.environment", String), "standard-jvm")
+  }
+  configurations.getByName(compileClasspathConfigurationName) {
+    attributes.attribute(Attribute.of("org.gradle.jvm.environment", String), "standard-jvm")
+  }
+}
 
 test {
     testLogging {


### PR DESCRIPTION
##  Release notes

Initially tried to upgrade to the latest release, `org.apache:calcite-core:1.39.0` but as noted in 2f36525982c6c5bfcbdced3a4c85febe34fefd18 doing so led to Gradle resolution issues while retrieving more recent versions of `guava`. This issue is described in the `Changelog` section of https://github.com/google/guava/releases/tag/v32.1.0 and seems to be only happening on Gradle 6.x. When these components get upgraded to support Gradle 7.x or 8.x this can be revisited and a second round of upgrade can be scheduled.

In the meantime, the dependency has been upgraded to 1.35.0 which is the latest release where there are no dependency resolution issue and all the release notes for each version since 1.20.0 are available at:

- https://calcite.apache.org/docs/history.html#v1-21-0
- https://calcite.apache.org/docs/history.html#v1-22-0
- https://calcite.apache.org/docs/history.html#v1-23-0
- https://calcite.apache.org/docs/history.html#v1-24-0
- https://calcite.apache.org/docs/history.html#v1-25-0
- https://calcite.apache.org/docs/history.html#v1-26-0
- https://calcite.apache.org/docs/history.html#v1-27-0
- https://calcite.apache.org/docs/history.html#v1-28-0
- https://calcite.apache.org/docs/history.html#v1-29-0
- https://calcite.apache.org/docs/history.html#v1-30-0
- https://calcite.apache.org/docs/history.html#v1-31-0
- https://calcite.apache.org/docs/history.html#v1-32-0
- https://calcite.apache.org/docs/history.html#v1-33-0
- https://calcite.apache.org/docs/history.html#v1-34-0
- https://calcite.apache.org/docs/history.html#v1-35-0

## Testing

`org.apache.calcite-core` was introduced in https://github.com/ome/omero-server/commit/75c82f40071a9222b4f2bbfd039951e2bcc251e5 and is primarily used in the context of `ome.tools.hibernate.SqlQueryTransformer`.

Functionally, testing should be primarily to ensure that various Hibernate queries return the expected results. Specifically, as per https://www.openmicroscopy.org/security/advisories/2019-SV3/, queries for other `Experimenter` made by a non administrator should return partial information for all users that are not also part of a shared collaborative group.