### PR TITLE
Bump org.openmicroscopy:omero-renderer from 5.6.2 to 5.6.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     testImplementation("jmock:jmock:1.+")
     testImplementation('org.openmicroscopy:omero-common-test:5.7.2')
 
-    api('org.openmicroscopy:omero-renderer:5.6.2')
+    api('org.openmicroscopy:omero-renderer:5.6.3')
 
     // Spring framework stuff
     implementation("org.springframework:spring-context-support:4.3.30.RELEASE")


### PR DESCRIPTION
See https://github.com/ome/omero-renderer/releases/tag/v5.6.3 for the list of changes