### PR TITLE
OMEROMetadataStore: compare IEnum objects identifiers by value

### DIFF
--- a/src/main/java/ome/formats/OMEROMetadataStore.java
+++ b/src/main/java/ome/formats/OMEROMetadataStore.java
@@ -2000,15 +2000,15 @@ public class OMEROMetadataStore
      */
     private static boolean compare(IEnum a, IEnum b)
     {
-      if (a == null && b == null)
-      {
-        return true;
-      }
-      if (a == null || b == null)
-      {
-        return false;
-      }
-      return a.getId().equals(b.getId());
+        if (a == null && b == null)
+        {
+            return true;
+        }
+        if (a == null || b == null)
+        {
+            return false;
+        }
+        return a.getId().equals(b.getId());
     }
     
     /**

--- a/src/main/java/ome/formats/OMEROMetadataStore.java
+++ b/src/main/java/ome/formats/OMEROMetadataStore.java
@@ -1996,19 +1996,19 @@ public class OMEROMetadataStore
      * @param a First OMERO model object.
      * @param b Second OMERO model object.
      * @return <code>true</code> if <code>a == null && b == null</code>, 
-     * <code>a == b</code> or <code>a.getId() == b.getId()</code>.
+     * or <code>a.getId().equals(b.getId())</code>.
      */
     private static boolean compare(IEnum a, IEnum b)
     {
-    	if (a == null && b == null)
-    	{
-    		return true;
-    	}
-    	if (a == null || b == null)
-    	{
-    		return false;
-    	}
-    	return a.getId() == b.getId();
+      if (a == null && b == null)
+      {
+        return true;
+      }
+      if (a == null || b == null)
+      {
+        return false;
+      }
+      return a.getId().equals(b.getId());
     }
     
     /**


### PR DESCRIPTION
Fixes #204

## Summary

This change improves the implementation of `OMEROMetadataStore.compare(IEnum, IEnum)` to use `equals` and compare identifiers by value rather than by reference. 
In practice, the current implementation might have been working for most `IEnum` objects. This is due to the fact the JVM uses a cache for Integer values and  comparing `Long` objects by reference works up to 127:


```java
import java.lang.Long;
Long a;
Long b;
Long[] values = {1L, 10L, 100L, 1000L, 127L, 128L};

for (int i=0; i< values.length; i++) {
  a = Long.valueOf(values[i]);
  b = Long.valueOf(values[i]);
  System.out.println(values[i]);
  System.out.println(a == b);
  System.out.println(a.equals(b));
}
```

yields

```
1
true
true
10
true
true
100
true
true
1000
false
true
127
true
true
128
false
true
```

## Testing

The nightly CI tests should be unaffected by this change. 


`OMEROMetadataStore.compare(IEnum, IEnum)` is used internally by the `OMEROMetadataStore.getUniqueLightSettings`, `OMEROMetadataStore.getUniqueObjectiveSettings`, `OMEROMetadataStore.getUniqueDetectorSettings`, `OMEROMetadataStore.getUniqueLightPath` and `OMEROMetadataStore.getUniqueLogicalChannel` APIs to compare objects with similar attributes and reduce the object graph. This is critical in particular for the performance of high-content screening imports to avoid the creation of thousands of duplicated objects in the database - see https://github.com/ome/openmicroscopy/pull/3261 for a set of changes trying to reduce the number of light path objects.

To test the existing behavior, either pick a HCS format with sufficient instrument metadata including notably objects with enumerations like `Objective`, `Filter`... As an example using the [synthetic images](https://bio-formats.readthedocs.io/en/stable/developers/generating-test-images.html), `test&plateRows=2&plateCols=2&sizeC=2.fake` should create a plate with 4 Image, 2 channels each linked to filters, detectors and objectives.

After importing this sample into OMERO, check the import log file created under the ManagedRepository. This should include statements about the number of unique object

```
2026-03-19 15:28:40,282 INFO  [          ome.formats.OMEROMetadataStore] (erver-4393) Unique objective settings: 0
2026-03-19 15:28:40,282 INFO  [          ome.formats.OMEROMetadataStore] (erver-4393) Unique light settings: 1
2026-03-19 15:28:40,282 INFO  [          ome.formats.OMEROMetadataStore] (erver-4393) Unique detector settings: 1
2026-03-19 15:28:40,282 INFO  [          ome.formats.OMEROMetadataStore] (erver-4393) Unique light paths: 1
2026-03-19 15:28:40,282 INFO  [          ome.formats.OMEROMetadataStore] (erver-4393) Unique logical channels: 2
```

as well as INSERT calls confirming only the minimal number of objects are created in the database. 

This behavior should be unchanged with and without this PR